### PR TITLE
fix: Syntax fix for index documents inside Waku folders

### DIFF
--- a/waku/README.md
+++ b/waku/README.md
@@ -1,4 +1,4 @@
-## Waku RFCs
+# Waku RFCs
 
 Waku builds a family of privacy-preserving, censorship-resistant communication protocols for web3 applications.
 

--- a/waku/deprecated/README.md
+++ b/waku/deprecated/README.md
@@ -1,4 +1,4 @@
-## Deprecated RFCs 
+# Deprecated RFCs 
 
 Deprecated specifications are no longer used in Waku products.
 This subdirectory is for achrive purpose and 


### PR DESCRIPTION
# What does this PR resolve? 🚀
- Changes title inside Waku/README.md from h2 to h1
- Changes title inside Waku/Deprecated/README.md from h2 to h1

# Details 📝
The syntax for the title of the markdown seems to not be proper one comparing to other README documents.
It's important to define titles with h1(#) to be able to parse it properly later on by the website