### PR TITLE
Update 13/STORE: new error codes for Extended HistoryResponse

### DIFF
--- a/waku/standards/core/13/store.md
+++ b/waku/standards/core/13/store.md
@@ -105,6 +105,8 @@ message HistoryResponse {
   enum Error {
     NONE = 0;
     INVALID_CURSOR = 1;
+    TOO_MANY_REQUESTS = 429;
+    SERVICE_UNAVAILABLE = 503;
   }
   Error error = 4;
 }


### PR DESCRIPTION
This is a small adjustment on new error codes introduced for waku's store protocol response.
Change is introduced by https://github.com/waku-org/pm/issues/66 implementation.
