### PR TITLE
Update .markdownlint.json

### DIFF
--- a/.github/workflows/.markdownlint.json
+++ b/.github/workflows/.markdownlint.json
@@ -1,6 +1,9 @@
 {
         "MD013": {
                 "tables": false,
-                "code_blocks" : false
+                "code_blocks" : false,
+                "line_length" : false
         }
+        
+        "MD024": false
 }


### PR DESCRIPTION
Remove 80 characters line length requirement
- Semantic breaks must still be enforced. 
Remove requirements to remove headings with the same content. 
- If multiple headings have the same headings, those headings should not be referenced within the document.