### PR TITLE
Update peer-exchange.md to fix a build error

### DIFF
--- a/waku/standards/core/34/peer-exchange.md
+++ b/waku/standards/core/34/peer-exchange.md
@@ -56,7 +56,7 @@ The responder replies with a list of ENRs as specified in [WAKU2-ENR](https://gi
 The [multiaddresses](https://docs.libp2p.io/concepts/addressing/)
 used to connect to the respective peers can be extracted from the ENRs.
 
-![Figure 1: The responder provides a list of ENRs to the requester. These ENRs contain the information necessary for connecting to the respective peers.](/waku/standards/core/34/images/protocol.svg)
+![Figure 1: The responder provides a list of ENRs to the requester. These ENRs contain the information necessary for connecting to the respective peers.](./images/protocol.svg)
 
 In order to protect its anonymity,
 the responder MUST NOT provide peers from its actively used peer list


### PR DESCRIPTION
<img width="1714" alt="Screenshot 2024-12-06 at 8 29 20 PM" src="https://github.com/user-attachments/assets/b3fce6c4-48e8-44a6-8f7d-64e42002e121">


Images should be defined using relative paths to successfully build https://rfc.vac.dev/, which is powered by Docusaurus.

I have verified that this update resolves the build issue locally.