### PR TITLE
add usage guidelines for waku content topics

### DIFF
--- a/waku/informational/23/topics.md
+++ b/waku/informational/23/topics.md
@@ -129,6 +129,18 @@ to indicate different bandwidth and privacy guarantees.
 The encoding field indicates the serialization/encoding scheme
 for the [WakuMessage payload](../../standards/core/14/message.md/#payloads) field.
 
+### Content Topic usage guidelines
+
+Applications should be mindful while designing/using content topics so that a bloat of content-topics does not happen. 
+A content topic bloat causes performance degradation in Store and Filter protocols while trying to retrieve messages.
+
+Store queries have been noticed to be considerably slow (e.g doubling of response-time when content-topic count is increased from 10 to 100) when a lot of content-topics are involved in a single query.
+Similarly number of filter subscriptions increase, which increases complexity on client side to maintain and manage these subscriptions.
+
+Applications should analyze the query/filter criteria for fetching messages from the network and select/design content topics to match such filter criteria. 
+e.g: eventhough applications may want to segregate messages into different sets based on some application logic, if those sets of messages are always fetched/queried together from the network, then all those messages should use a single content-topic. 
+
+
 ## Differences with Waku v1
 
 In [5/WAKU1](../../deprecated/5/waku0.md) there is no actual routing.


### PR DESCRIPTION
Included a small section on usage guidelines for waku content topics. 

It was observed that in status communities these guidelines were not followed which is being fixed based on [discussion post](https://forum.vac.dev/t/status-communities-review-and-proposed-usage-of-waku-content-topics/335) . 
Hence adding an explicit section will help app developers design content-topics accordingly.