### PR TITLE
update communities spec as per content topic changes

### DIFF
--- a/status/56/communities.md
+++ b/status/56/communities.md
@@ -423,7 +423,7 @@ contentTopic = "/waku/1/0x" + topic + "/rfc26"
 
 #### Community channels/chats
 
-All channels/chats shall use a single content-topic which is derived based on a universal chat id ir-respective of their individual unique chat ids.
+All channels/chats shall use a single content-topic which is derived from a universal chat id irrespective of their individual unique chat ids.
 
 ### Community Management
 


### PR DESCRIPTION
- [x] Update content topic usage as per https://forum.vac.dev/t/status-communities-review-and-proposed-usage-of-waku-content-topics/335
- [x] Update symmetric encryption done at content topic level before messages are handed over to waku
- [x] Update about shard or pubsub topic usage
~- [ ] update communities flows as per current understanding~

Anything else that can be added please let me know.

@jm-clius  i have tried to brief about community shards in this spec, not sure if that in itself be a separate spec with a ref included here. Please advise.