### PR TITLE
Add the Notion reference for Nomos specifications

### DIFF
--- a/nomos/README.md
+++ b/nomos/README.md
@@ -2,6 +2,5 @@
 
 Nomos is building a secure, flexible, and
 scalable infrastructure for developers creating applications for the network state.
-Published Specifications are currently available here, 
+Published Specifications are currently available here,
 [Nomos Specifications](https://nomos-tech.notion.site/project).
-


### PR DESCRIPTION
Ideally these specifications were tracked as RFCs, but in the meantime we should have a link to the Notion.