### PR TITLE
Fix SDS lamport timestamp overflow and keep it near current time

### DIFF
--- a/vac/raw/sds.md
+++ b/vac/raw/sds.md
@@ -81,7 +81,7 @@ message Message {
   string sender_id = 1;           // Participant ID of the message sender
   string message_id = 2;          // Unique identifier of the message
   string channel_id = 3;          // Identifier of the channel to which the message belongs
-  optional int32 lamport_timestamp = 10;    // Logical timestamp for causal ordering in channel
+  optional uint32 lamport_timestamp = 10;    // Logical timestamp for causal ordering in channel
   repeated HistoryEntry causal_history = 11;  // List of preceding message IDs that this message causally depends on. Generally 2 or 3 message IDs are included.
   optional bytes bloom_filter = 12;         // Bloom filter representing received message IDs in channel
   optional bytes content = 20;             // Actual content of the message
@@ -111,7 +111,7 @@ Its importance is expected to increase once a p2p retrieval mechanism is added t
 Each participant MUST maintain:
 
 * A Lamport timestamp for each channel of communication,
-initialized to current epoch time in millisecond resolution.
+initialized to current epoch time in second resolution.
 * A bloom filter for received message IDs per channel.
 The bloom filter SHOULD be rolled over and
 recomputed once it reaches a predefined capacity of message IDs.


### PR DESCRIPTION
The SDS timestamp is initialized to the current time in milliseconds, which is a 13 digits value (e.g. 1,759,223,090,052).

The maximum value for int32 is 2,147,483,647 (10 digits), which is clearly less than the timestamp. Maximum value for uint32 is 4,294,967,295 (10 digits), which does not help either.

uint64 is BigInt in JavaScript, so best to be avoided unless strictly necessary as it creates complexity. max uint64 is 18,446,744,073,709,551,615 (20 digits).

Using seconds instead of milliseconds would enable usage of uint32 valid until the year 2106.

The lamport timestamp is only initialized to current time for a new channel. The only scenario is when a user comes in a channel, and thinks it's new (did not get previous messages), and then starts sending messages. Meaning that there may be an initial timestamp conflict until the logs are consolidated, which is already handled by the protocol.

JS implementation: https://github.com/waku-org/js-waku/pull/2664