### PR TITLE
de-MLS RFC name change

### DIFF
--- a/docs/ift-ts/raw/decentralized-mls-offchain-consensus.md
+++ b/docs/ift-ts/raw/decentralized-mls-offchain-consensus.md
@@ -1,8 +1,8 @@
-# ETH-MLS-OFFCHAIN
+# DECENTRALIZED-MLS-OFFCHAIN-CONSENSUS
 
 | Field | Value |
 | --- | --- |
-| Name | Secure channel setup using decentralized MLS and Ethereum accounts |
+| Name | Secure channel setup using decentralized MLS |
 | Slug | 104 |
 | Status | raw |
 | Category | Standards Track |
@@ -25,7 +25,7 @@
 
 ## Abstract
 
-The following document specifies Ethereum authenticated scalable
+The following document specifies scalable
 and decentralized secure group messaging application by
 integrating Message Layer Security (MLS) backend.
 Decentralization refers each user is a node in P2P network and

--- a/docs/ift-ts/raw/decentralized-mls-offchain-consensus.md
+++ b/docs/ift-ts/raw/decentralized-mls-offchain-consensus.md
@@ -64,7 +64,7 @@ are to be interpreted as described in [2119](https://www.ietf.org/rfc/rfc2119.tx
 - The presence of non-reliable (silent) nodes MAY be assumed.
 - A lightweight, scalable consensus mechanism with deterministic finality within a specific time MUST be employed.
 - The network MUST enforce a rate-limiting mechanism for all entities in order to mitigate spam.
-- \textbf{$\Delta$ (Delta)} is a protocol parameter denoting a bounded time interval (in seconds)
+- $\Delta$ (Delta) is a protocol parameter denoting a bounded time interval (in seconds)
 that defines the maximum synchronization window of the system.
 - At least $2n/3$ of the members MUST become synchronized within $\Delta$ time, where $n$ is the group size.
 


### PR DESCRIPTION
Since Ethereum-based authentication has been removed from de-MLS, this PR updates the name accordingly.