### PR TITLE
Add SURB specification (§8.7)

### DIFF
--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -359,7 +359,8 @@ Common strategies include Proof of Work (PoW), Verifiable Delay Functions (VDFs)
 The sender is responsible for appending the appropriate exit abuse prevention data (_e.g.,_ nonce, timestamp) to the message payload.
 The format and verification logic depend on the selected method.
 
-Note: The exit abuse prevention mechanisms described above are intended to protect the exit from flooding attacks routed through them.
+Note:
+The exit abuse prevention mechanisms described above are intended to protect the exit from flooding attacks routed through them.
 They do not provide protection against denial-of-service (DoS) or resource exhaustion attacks targeting the mixnet itself (_e.g.,_ flooding mix nodes with traffic, inducing processing overhead, or targeting bandwidth).
 
 Protections against attacks targeting the mixnet itself are addressed in [Section 6.6](#66-dos-protection).
@@ -634,6 +635,9 @@ The recommended total packet size is $4608$ bytes, chosen to:
 - Allow inclusion of additional data such as SURBs without requiring fragmentation,
 - Maintain reasonable per-hop processing and bandwidth overhead.
 
+Note:
+When [DoS protection](#66-dos-protection) is enabled, the maximum packet size MUST be increased to accommodate the proof size of the chosen DoS protection mechanism.
+
 This recommended total packet size of $4608$ bytes yields:
 
 $`
@@ -663,8 +667,6 @@ Implementers SHOULD align with widely used defaults to maximize anonymity set si
 Similarly, parameters such as $r$ and $t$ are configurable.
 Changes to these parameters affect header size and therefore impact payload size if the total packet size remains fixed.
 However, if such changes alter the total packet size on the wire, the same anonymity set considerations apply.
-
-When DoS protection is enabled (see [Section 6.6](#66-dos-protection)), the total wire size may increase depending on the integration approach.
 
 The following subsection defines how the next-hop or destination address and forwarding delay are encoded within $β$ to enable correct routing and mixing behavior.
 

--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -6,8 +6,8 @@
 | Slug | 99 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Prem Prathi <prem@status.im>|
-| Contributors | Akshaya Mani <akshaya@status.im>, Daniel Kaiser <danielkaiser@status.im>, Hanno Cornelius |
+| Editor | Akshaya Mani <akshaya@status.im>|
+| Contributors | Prem Prathi <prem@status.im>, Daniel Kaiser <danielkaiser@status.im>, Hanno Cornelius |
 
 <!-- timeline:start -->
 
@@ -116,7 +116,7 @@ However, Tor relies on session persistence and is ill-suited for protocols requi
 
 The Mix Protocol addresses this gap with a decentralized message routing layer based on classical mix network principles.
 It applies layered encryption and per-hop delays to obscure both routing paths and timing correlations.
-Each message is routed independently, providing resistance to traffic analysis and protection against metadata leakage
+Each message is routed independently, providing resistance to traffic analysis and protection against metadata leakage.
 
 By decoupling anonymity from connection state and transport negotiation, the Mix Protocol offers a modular privacy abstraction that existing libp2p protocols can adopt without altering their core behavior.
 
@@ -177,7 +177,7 @@ Even mix nodes learn only the immediate routing information and the delay to be 
 They do not learn their position in the path or the total number of hops.
 
 The packet format is resistant to tagging and replay attacks and is compact and efficient to process.
-Sphinx packets also include per-hop integrity checks and enforces a maximum path length.
+Sphinx packets also include per-hop integrity checks and enforce a maximum path length.
 Together with a constant-size header and payload, this provides bounded protection against endless routing and malformed packet propagation.
 
 It also supports anonymous and indistinguishable reply messages through [Single-Use Reply Blocks (SURBs)](https://cypherpunks.ca/~iang/pubs/Sphinx_Oakland09.pdf), although reply support is not implemented yet.
@@ -297,8 +297,8 @@ Mix Protocol implementations MUST NOT assume persistent stream availability and 
 Pluggable components define functionality that extends or configures the behavior of the Mix Protocol beyond its core message routing logic.
 Each component in this section falls into one of two categories:
 
-- Required for interoperability and path construction (_e.g.,_ discovery, delay strategy).
-- Optional or deployment-specific (_e.g._ spam protection, cover traffic, incentivization).
+- Required for interoperability and path construction (_e.g.,_ discovery, delay strategy, DoS protection).
+- Optional or deployment-specific (_e.g.,_ exit abuse prevention, cover traffic, incentivization).
 
 The following subsections describe the role and expected behavior of each.
 
@@ -345,22 +345,24 @@ However, any delay strategy MUST ensure that:
 Strategies that produce deterministic or tightly clustered output delays are NOT RECOMMENDED, as they increase the risk of timing correlation.
 Delay strategies SHOULD introduce enough uncertainty to prevent adversaries from linking packet arrival and departure times, even when monitoring multiple hops concurrently.
 
-### 6.3 Spam Protection
+### 6.3 Exit Abuse Prevention
 
-The Mix Protocol supports an optional, pluggable spam protection mechanism to defend the mixnet against denial-of-service (DoS) or resource exhaustion attacks.
-Without spam protection, malicious actors could flood mix nodes with valid Sphinx packets, exhausting computational resources or bandwidth of the mix nodes eventually making them unusable.
-Spam protection is critical to make the mixnet robust enough to be used in a production environment.
+The Mix Protocol supports optional exit abuse prevention mechanisms to defend
+exits against flooding attacks routed through them.
+These mechanisms are validated at the exit node, which is the final node in the mix path before the message is delivered to its destination via the respective libp2p protocol.
 
-The spam protection mechanism is pluggable because different deployments may require different trade-offs between computational overhead, attack resistance, and Sybil resistance.
-For a specific mix deployment, the same spam protection mechanism MUST be followed by all participating mix nodes to ensure interoperability.
+Exit nodes that enforce exit abuse prevention MUST validate the attached proof before forwarding the message.
+If validation fails, the message MUST be discarded.
 
-Two primary architectural approaches exist for integrating spam protection: sender-generated proofs and per-hop generated proofs.
-Each approach has distinct implications for computational overhead, latency, security properties, Sybil resistance, and implementation complexity.
+Common strategies include Proof of Work (PoW), Verifiable Delay Functions (VDFs), and Rate-limiting Nullifiers (RLNs).
 
-Detailed design requirements, architectural approaches, packet structure considerations, node responsibilities, and recommendations are specified in [Section 9](#9-spam-protection-architecture).
+The sender is responsible for appending the appropriate exit abuse prevention data (_e.g.,_ nonce, timestamp) to the message payload.
+The format and verification logic depend on the selected method.
 
-Note that application-level or origin-protocol spam protection mechanisms are out of scope for the Mix Protocol and MUST be handled by the appropriate protocol layer itself.
-For example, Waku protocols use RLN (Rate Limiting Nullifiers) for spam protection, which is handled by [Waku-Relay](https://rfc.vac.dev/waku/standards/core/17/rln-relay) protocol, and the RLN proof would be included as part of the mix payload.
+Note: The exit abuse prevention mechanisms described above are intended to protect the exit from flooding attacks routed through them.
+They do not provide protection against denial-of-service (DoS) or resource exhaustion attacks targeting the mixnet itself (_e.g.,_ flooding mix nodes with traffic, inducing processing overhead, or targeting bandwidth).
+
+Protections against attacks targeting the mixnet itself are addressed in [Section 6.6](#66-dos-protection).
 
 ### 6.4 Cover Traffic
 
@@ -397,6 +399,17 @@ Additionally, network operators or application-layer policies MAY require nodes 
 
 While the Mix Protocol defines a minimum participation requirement, additional incentivization extensions are considered pluggable and experimental in this version of the specification.
 No specific mechanism is standardized.
+
+### 6.6 DoS Protection
+
+The Mix Protocol supports a pluggable DoS protection mechanism to defend the mixnet against denial-of-service (DoS) or resource exhaustion attacks.
+Without DoS protection, malicious actors could flood mix nodes with valid Sphinx packets, exhausting computational resources or bandwidth of the mix nodes, eventually making them unusable.
+Deployments MUST implement a DoS protection mechanism to make the mixnet robust under adversarial conditions.
+
+The DoS protection mechanism is pluggable because different deployments may require different trade-offs between computational overhead, attack resistance, and Sybil resistance.
+For a specific mix deployment, the same DoS protection mechanism MUST be followed by all participating mix nodes to ensure interoperability.
+
+Detailed design requirements, architectural approaches, packet structure considerations, node responsibilities, and recommendations are specified in [Mix DoS Protection](./mix-dos-protection.md).
 
 ## 7. Core Mix Protocol Responsibilities
 
@@ -459,6 +472,8 @@ A mix node performing intermediary processing MUST treat each packet as stateles
 To process a Sphinx packet as an exit, a mix node MUST:
 
 - Extract the plaintext message from the final decrypted packet.
+- Validate any attached exit abuse prevention proof.
+- Discard the message if validation fails.
 - Forward the valid message to the Mix Exit Layer for delivery to the destination origin protocol instance.
 
 The node MUST NOT retain decrypted content after forwarding.
@@ -562,7 +577,7 @@ The header consists of the fields $α$, $β$, and $γ$, totaling a fixed size pe
 - **$α$ (Alpha)**: 32 bytes
   The size of $α$ is determined by the elliptic curve group representation used (Curve25519), which encodes group elements as 32-byte values.
 
-- **$β$ (Beta)**: $((t + 1)r + 1)κ$ bytes
+- **$β$ (Beta)**: $(r(t + 1) + 1)κ$ bytes
   The size of $β$ depends on:
 
   - **Maximum path length ($r$)**: The recommended value of $r=5$ balances bandwidth versus anonymity tradeoffs.
@@ -649,8 +664,7 @@ Similarly, parameters such as $r$ and $t$ are configurable.
 Changes to these parameters affect header size and therefore impact payload size if the total packet size remains fixed.
 However, if such changes alter the total packet size on the wire, the same anonymity set considerations apply.
 
-When spam protection is enabled (see [Section 9](#9-spam-protection-architecture)), the total wire size may increase depending on the integration approach.
-For per-hop generated proofs, the proof is appended after the Sphinx packet, and the proof size MUST be fixed to maintain packet indistinguishability.
+When DoS protection is enabled (see [Section 6.6](#66-dos-protection)), the total wire size may increase depending on the integration approach.
 
 The following subsection defines how the next-hop or destination address and forwarding delay are encoded within $β$ to enable correct routing and mixing behavior.
 
@@ -685,7 +699,7 @@ For interoperability, a recommended default encoding format involves:
   - Peer IDs (39 bytes, post-Base58 decoding)
 
 - Encoding the forwarding delay as an unsigned 16-bit integer (2 bytes), representing the mean delay in milliseconds for the configured delay distribution, using big endian network byte order.
-  The delay distribution is pluggable, as defined in [Section 6.2](#62-delay-strategy).
+The delay distribution is pluggable, as defined in [Section 6.2](#62-delay-strategy).
 
 If the encoded address or delay is shorter than its respective allocated field, it MUST be padded with zeros.
 If it exceeds the allocated size, it MUST be rejected or truncated according to the implementation policy.
@@ -707,7 +721,7 @@ The construction process wraps the message in a sequence of encryption layers&md
 To initiate the Mix Protocol, the origin protocol instance submits a message to the Mix Entry Layer on the same node.
 This layer forwards it to the local Mix Protocol instance, which constructs a Sphinx packet using the following REQUIRED inputs:
 
-- **Application message**: The serialized message provided by the origin protocol instance. The Mix Protocol instance attaches one or two SURBs prior to encapsulating the message in the Sphinx packet. The initiating node MUST ensure that the resulting payload size does not exceed the maximum supported size defined in [Section 8.3.2](#832-payload-size).
+- **Application message**: The serialized message provided by the origin protocol instance. The Mix Protocol instance applies any configured exit abuse prevention mechanism and attaches one or two SURBs prior to encapsulating the message in the Sphinx packet. The initiating node MUST ensure that the resulting payload size does not exceed the maximum supported size defined in [Section 8.3.2](#832-payload-size).
 - **Origin protocol codec**: The libp2p protocol string corresponding to the origin protocol instance. This is included in the payload so that the exit node can route the message to the intended destination protocol after decryption.
 - **Mix Path length $L$**: The number of mix nodes to include in the path. The mix path MUST consist of at least three hops, each representing a distinct mix node.
 - **Destination address $Δ$**: The routing address of the intended recipient of the message. This address is encoded in $(tκ - 2)$ bytes as defined in [Section 8.4](#84-address-and-delay-encoding) and revealed only at the last hop.
@@ -721,6 +735,8 @@ The construction MUST proceed as follows:
 
 1. **Prepare Application Message**
 
+   - Apply any configured exit abuse prevention mechanism (_e.g.,_ PoW, VDF, RLN) to the serialized message.
+   Exit abuse prevention mechanisms are pluggable as defined in [Section 6.3](#63-exit-abuse-prevention).
    - Attach one or more SURBs, if required. Their format and processing are specified in [Section X.X].
    - Append the origin protocol codec in a format that enables the exit node to reliably extract it during parsing. A recommended encoding approach is to prefix the codec string with its length, encoded as a compact varint field limited to two bytes. Regardless of the scheme used, implementations MUST agree on the format within a deployment to ensure deterministic decoding.
    - Pad the result to the maximum application message length of $3968$ bytes using a deterministic padding scheme. This value is derived from the fixed payload size in [Section 8.3.2](#832-payload-size) ($3984$ bytes) minus the security parameter $κ = 16$ bytes defined in [Section 8.2](#82-cryptographic-primitives). The chosen scheme MUST yield a fixed-size padded output and MUST be consistent across all mix nodes to ensure correct interpretation during unpadding. For example, schemes that explicitly encode the padding length and prepend zero-valued padding bytes MAY be used.
@@ -740,6 +756,7 @@ The construction MUST proceed as follows:
 
    - Choose a random private exponent $x \in_R \mathbb{Z}_q^*$.
    - Initialize:
+
      $`
      \begin{aligned}
      α_0 &= g^x \\
@@ -748,6 +765,7 @@ The construction MUST proceed as follows:
      \end{aligned}
      `$
    - For each hop $i$ (from $1$ to $L-1$), compute:
+
      $`
      \begin{aligned}
      α_i &= α_{i-1}^{b_{i-1}} \\
@@ -759,6 +777,7 @@ The construction MUST proceed as follows:
    Note that the length of $α_i$ is $32$ bytes, $0 \leq i \leq L-1$ as defined in [Section 8.3.1](#831-header-field-sizes).
 
    b. **Compute Per-Hop Filler Strings**
+
    Filler strings are encrypted strings that are appended to the header during encryption.
    They ensure that the header length remains constant across hops, regardless of the position of a node in the mix path.
 
@@ -783,10 +802,11 @@ The construction MUST proceed as follows:
        $`
        \begin{array}{l}
        Φ_i = \mathrm{AES\text{-}CTR}'_i\bigl(Φ_{\mathrm{aes\_key}_{i-1}},
-       Φ_{\mathrm{iv}_{i-1}}, Φ_{i-1} \mid 0_{(t+1)κ} \bigr), \\
-       \text{where } 0_x \text{ defines the string of } 0 \text{ bits of length } x\text{.}
+       Φ_{\mathrm{iv}_{i-1}}, Φ_{i-1} \mid 0_{(t+1)κ} \bigr)
        \end{array}
        `$
+
+       where $0_x$ defines the string of $0$ bits of length $x$.
 
    Note that the length of $Φ_i$ is $(t+1)iκ$, $0 \leq i \leq L-1$.
 
@@ -835,11 +855,11 @@ The construction MUST proceed as follows:
        \begin{array}{l}
        β_i = \mathrm{AES\text{-}CTR}\bigl(β_{\mathrm{aes\_key}_i},
        β_{\mathrm{iv}_i}, \mathrm{addr}_{i+1} \mid \mathrm{delay}_i
-       \mid γ_{i+1} \mid β_{i+1 \, [0 \ldots (r(t+1) - t)κ - 1]} \bigr),\\
-       \text{where notation } X_{[a \ldots b]} \text{ denotes the substring of } X
-       \text{ from byte offset } a \text{ to } b\text{, inclusive, using zero-based indexing.}
+       \mid γ_{i+1} \mid β_{i+1 \, [0 \ldots (r(t+1) - t)κ - 1]} \bigr)
        \end{array}
        `$
+
+       where $X_{[a \ldots b]}$ denotes the substring of $X$ from byte offset $a$ to $b$, inclusive, using zero-based indexing.
 
      Note that the length of $\beta_i$ is $(r(t+1)+1)κ$, $0 \leq i \leq L-1$ as defined in [Section 8.3.1](#831-header-field-sizes).
 
@@ -910,7 +930,7 @@ The construction MUST proceed as follows:
 
    f. **Transmit Packet**
 
-   - Sample a randomized delay from the same distribution family used for per-hop delays (in Step 3.e.) with an independently chosen mean.
+   - Sample a randomized delay from the same distribution family used for per-hop delays (in Step 3.c.) with an independently chosen mean.
 
    This delay prevents timing correlation when multiple Sphinx packets are sent in quick succession.
    Such bursts may occur when an upstream protocol fragments a large message, or when several messages are sent close together.
@@ -1035,7 +1055,7 @@ As described in [Section 8.6.1](#861-shared-preprocessing), the mix node obtains
 
 At this stage, the node MUST determine whether it is an intermediary or the exit based on the prefix of $B$, in accordance with the construction of $β_i$ defined in [Section 8.5.2](#852-construction-steps) step 3.c.:
 
-- If the first $(tκ - 2)$ bytes of $B$ contain a nonzero-encoded address, immediately followed by a two-byte zero delay, and then $((t + 1)(r - L) + t + 2)κ$ bytes of all-zero padding, process the packet as an exit.
+- If the first $(tκ - 2)$ bytes of $B$ contain a nonzero-encoded address immediately followed by a two-byte zero delay, process the packet as an exit.
 - Otherwise, process the packet as an intermediary.
 
 The following subsections define the precise behavior for each case.
@@ -1162,11 +1182,11 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
      $`
      \begin{array}{l}
-     m = δ'_{[κ\ldots]},\; \; \;
-     \text{where notation } X_{[a \ldots]} \text{ denotes the substring of } X
-     \text{ from byte offset } a \text{ to the end of the string using zero-based indexing.}
+     m = δ'_{[κ\ldots]}
      \end{array}
      `$
+
+     where $X_{[a \ldots]}$ denotes the substring of $X$ from byte offset $a$ to the end of the string, using zero-based indexing.
 
 3. **Extract Application Message**
 
@@ -1176,11 +1196,12 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
    - Next, parse the unpadded message deterministically to extract:
 
+     - optional exit abuse prevention proof
      - zero or more SURBs
      - the origin protocol codec
      - the serialized application message
 
-   - Extract SURBs , and identify protocol codec , consistent with the format and extensions applied by the initiator.
+   - Parse and deserialize the metadata fields required for exit abuse prevention validation, SURB extraction, and protocol codec identification, consistent with the format and extensions applied by the initiator.
      The application message itself MUST remain serialized.
 
    - If parsing fails at any stage, discard $m$ and terminate processing.
@@ -1191,333 +1212,14 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
    - The Exit Layer is responsible for establishing a client-only connection and forwarding the message to the destination. Implementations MAY reuse an existing stream to the destination, if doing so does not introduce any observable linkability between forwarded messages.
 
-## 9. Spam Protection Architecture
-
-This section provides detailed specifications for integrating a spam protection mechanism with the Mix Protocol.
-As introduced in [Section 6.3](#63-spam-protection), Mix protocol supports a pluggable spam protection mechanism.
-This section defines design requirements, architectural approaches, packet structure modifications, and node responsibilities for spam protection.
-This section also defines the interfaces between the Mix Protocol and spam protection mechanisms.
-
-### 9.1 Spam Protection Mechanism Requirements
-
-Any spam protection mechanism integrated with the Mix Protocol MUST satisfy the following requirements:
-
-- Each mix node in the path MUST verify proofs before applying delay and forwarding or taking further action (in the case of exit nodes).
-
-- Spam protection data and verification MUST NOT enable linking or correlating packets across hops.
-  Therefore, spam protection proofs MUST be unique per hop.
-
-- Spam protection proofs MUST NOT be reusable across different packets or hops.
-  Each hop SHOULD be able to detect replayed or forged proofs (e.g., via cryptographic binding to packet-specific or hop-specific data).
-
-- Proofs SHOULD be bound to unique signals per message that cannot be known in advance, preventing adversaries from pre-computing large batches of proofs offline for spam attacks.
-
-- Verification overhead MUST be low to minimise per-hop delays.
-  Otherwise, the spam protection mechanism would add substantial delay at each hop.
-
-- Proof generation and verification methods MUST preserve unlinkability of the sender and MUST NOT leak any additional metadata about the sender or node.
-
-- The mechanism SHOULD provide a way to punish spammers or detect misuse.
-
-### 9.2 Integration Architecture
-
-Two primary architectural approaches exist for integrating spam protection with the Mix Protocol, each with distinct trade-offs.
-This section elaborates on each approach and also lists down trade-offs and provides a comparison which helps in making a decision for deployments.
-
-#### 9.2.1 Sender-Generated Proofs
-
-In this approach, the sender generates spam protection proofs for all hops in the mix path during Sphinx packet construction.
-Proofs are embedded within each hop's routing block in the encrypted header $\beta$.
-
-##### 9.2.1.1 How It Works
-
-During Sphinx packet construction, as defined in [Section 8.5.2](#852-construction-steps), the sender follows the standard construction process (computing ephemeral secrets in step 3.a and encrypted payloads in step 3.d).
-After steps 3.a and 3.d, the sender additionally performs the following spam protection steps:
-
-1. **Generate and Embed Proofs:**
-   For each hop $i$ in the path:
-
-   a. The sender computes the spam protection proof cryptographically bound to $\delta_{i+1}$ (the decrypted payload that hop $i$ will compute).
-   This binding ensures proofs are path-specific and tied to specific encrypted message content, preventing proof extraction and reuse.
-
-   b. The proof and related metadata required for verification are embedded in hop $i$'s routing block within $\beta_i$ during header construction (step 3.c)
-
-2. **Verification at Each Hop:**
-   During Sphinx processing, hop $i$ decrypts $\beta_i$ to extract the proof and metadata, decrypts $\delta$ to get $\delta'$, then verifies the proof matches $\delta'$ using the provided metadata
-
-##### 9.2.1.2 Advantages
-
-- Only the sender performs the expensive proof generation.
-  Intermediate nodes only verify proofs, which is less expensive and also reduces latency per hop.
-- Each hop's proof is encrypted in a separate layer of $\beta$, making proofs unique per hop and cryptographically isolated.
-- Aligned with Sphinx philosophy wherein complexity is at the sender while intermediate nodes perform lightweight operations.
-
-##### 9.2.1.3 Disadvantages
-
-- Sender must generate $L$ proofs, which can be expensive.
-- Each hop's routing block must include spam protection data, increasing overall header and packet size (see impact analysis below).
-- Sender must know the full path before generating proofs and cannot reuse the proofs if two different paths are chosen for the same message.
-- Proofs can only be verified AFTER expensive Sphinx processing operations (session key derivation, replay checking, header integrity verification, and decryption), since they are encrypted within the $\beta$ field and bound to the decrypted payload state $\delta'$.
-  Deployments using this approach SHOULD augment with additional network-level protections (connection rate limiting, localized peer reputation) to defend against attacks that can lead to draining node's resources.
-- This approach does not inherently provide Sybil resistance as intermediate nodes do not generate any proof using their credentials.
-  A separate Sybil resistance mechanism (such as membership proofs) would be required, which would add additional data to the packet header.
-
-##### 9.2.1.4 Impact on Header Size
-
-If spam protection proofs are embedded in $\beta$, the per-hop routing block size increases from $(t+1)\kappa$ bytes to $(t+1)\kappa + |\mathrm{spam\_proof}|$ bytes.
-
-The total $\beta$ size becomes: $(r(t+1) + 1)\kappa + r \times |\mathrm{spam\_proof}|$ bytes, where $r$ is the maximum path length.
-
-With the current recommended values ($r=5$, $t=6$, $\kappa=16$):
-
-- Original header size: $624$ bytes
-- Header size increase: $5 \times |\mathrm{spam\_proof}|$ bytes
-
-Note that $|\mathrm{spam\_proof}|$ includes both the proof and all verification metadata.
-
-e.g. If using RLN, where proof + metadata ~= $300$ bytes, Header size becomes: $624 + 1500 = 2124$ bytes
-
-#### 9.2.2 Per-Hop Generated Proofs
-
-In this approach, each mix node generates a new spam protection proof for the next hop after verifying proof for the incoming packet.
-The proof $\sigma$ is appended after the Sphinx packet, forming the wire format: `SphinxPacket || σ`.
-The proof MAY be bound to the complete outgoing Sphinx packet $(\alpha' | \beta' | \gamma' | \delta')$.
-
-##### 9.2.2.1 How It Works
-
-1. The sender generates an initial spam protection proof $\sigma$ for the first hop and appends it after the Sphinx packet.
-   The proof MAY be cryptographically bound to the Sphinx packet and include any verification metadata required by the spam protection mechanism.
-2. The first hop extracts and verifies $\sigma$ before processing the Sphinx packet.
-3. After successful verification and Sphinx processing, the hop generates a new proof $\sigma'$ for the next hop bound to the transformed packet.
-4. The updated packet is forwarded to the next hop.
-5. This process repeats at each intermediate hop until the packet reaches the exit.
-
-##### 9.2.2.2 Advantages
-
-- Sender only generates one initial proof instead of $L$ proofs.
-- Spam protection data has less overhead on packet header size.
-- Proofs can be verified BEFORE expensive Sphinx processing operations (session key derivation, header integrity verification, and decryption).
-  This provides better DoS protection by allowing nodes to reject invalid packets earlier, before performing costly cryptographic operations.
-- If a membership-based spam protection mechanism is used (_e.g.,_ Rate Limiting Nullifiers), the same mechanism can provide Sybil resistance.
-  Nodes must prove membership or ownership of resources at each hop, making it economically infeasible to operate large numbers of Sybil nodes.
-
-##### 9.2.2.3 Disadvantages
-
-- Each node must generate fresh proofs, adding additional latency and processing cost at each hop.
-  The proof generation latency can be overcome by doing pre-computation of proofs but the proofs would not be bound to message contents rather some other means to add uniqueness.
-- When using rate-limiting mechanisms (such as RLN), intermediate nodes may exhaust their rate limits due to random path selection by multiple independent senders, causing legitimate packets to be dropped even when no individual sender is misbehaving.
-  This creates availability bottlenecks at popular nodes and unpredictable message delivery.
-  This can be mitigated by assigning higher rate-limits to intermediate or popular nodes(e.g. tied to reputation).
-
-##### 9.2.2.4 Impact on Packet Size
-
-The proof $\sigma$ is appended after the Sphinx packet, increasing total wire size to $4608 + |\sigma|$ bytes.
-The internal Sphinx packet structure remains unchanged.
-
-Note that $|\sigma|$ includes both the proof and all verification metadata.
-The proof size MUST be fixed for a given spam protection mechanism to ensure all packets remain indistinguishable on the wire (see [Section 8.3.4](#834-anonymity-set-considerations)).
-
-e.g. If using RLN, where proof + metadata ~= $300$ bytes, total wire size becomes: $4608 + 300 = 4908$ bytes
-
-#### 9.2.3 Comparison
-
-The following table provides a brief comparison between both integration approaches.
-
-| Aspect                             | Sender-Generated Proofs                 | Per-Hop Generated Proofs                   |
-| ---------------------------------- | --------------------------------------- | ------------------------------------------ |
-| **DoS protection**                 | Weaker (verify after Sphinx decryption) | Stronger (verify before Sphinx decryption) |
-| **Sender burden**                  | High (generates $L$ proofs)             | Low (generates 1 proof)                    |
-| **Per-hop computational overhead** | Low (verify only)                       | High (verify + generate)                   |
-| **Per-hop latency**                | Minimal (fast verification)             | Higher (mitigated with pre-computation)    |
-| **Total end-to-end latency**       | Lower                                   | Higher (mitigated with pre-computation)    |
-| **Sybil resistance**               | Requires separate mechanism             | Can be integrated                          |
-| **Packet size increase**           | $L \times \mathrm{spam\_proof}$         | $\|\sigma\|$                               |
-
-Separate specifications defining concrete spam protection mechanisms SHOULD specify recommended approaches and provide detailed integration instructions.
-
-### 9.3 Node Responsibilities
-
-In addition to the standard Sphinx processing responsibilities described in [Section 8](#8-sphinx-packet-format), nodes MUST implement the following spam protection responsibilities based on the chosen architectural approach.
-
-#### 9.3.1 For Sender-Generated Proofs
-
-- **Sender nodes**: MUST generate spam protection proofs for each hop during packet construction as described in [Section 9.2.1.1](#9211-how-it-works).
-  The sender MUST NOT include any identifying information in the proofs.
-
-- **Intermediate and exit nodes**: MUST verify the spam protection proof during packet processing as described in [Section 9.2.1.1](#9211-how-it-works).
-  Verification occurs after decrypting $\beta$ and $\delta$ during the shared preprocessing steps in [Section 8.6.1](#861-shared-preprocessing).
-  If verification fails, nodes MUST discard the packet and MAY apply penalties or rate-limiting measures.
-
-#### 9.3.2 For Per-Hop Generated Proofs
-
-- **Sender nodes**: MUST generate the initial spam protection proof $\sigma$ and append it after the Sphinx packet as described in [Section 9.2.2.1](#9221-how-it-works).
-  The proof MUST NOT contain identifying information.
-
-- **Intermediate nodes**: MUST extract and verify the incoming proof $\sigma$ BEFORE any Sphinx processing.
-  If verification fails, nodes MUST discard the packet and MAY apply penalties or rate-limiting measures.
-  After verification and Sphinx processing, nodes MUST generate a fresh unlinkable proof $\sigma'$ and append it to the transformed packet before forwarding.
-
-- **Exit nodes**: MUST extract and verify the incoming proof $\sigma$ before Sphinx processing.
-  Exit nodes do not generate new proofs.
-
-### 9.4 Anonymity and Security Considerations
-
-Spam protection mechanisms MUST be carefully designed to avoid introducing correlation risks:
-
-- **Timing side channels**: Proof verification and generation time SHOULD be constant to prevent packet fingerprinting through timing analysis.
-
-- **Proof uniqueness and unlinkability**: Each hop's proof MUST be unique and unlinkable from other hops' proofs.
-
-- **Verification failure handling**: Nodes MUST handle failures in a manner such that probing attacks can be prevented.
-
-- **Global state and coordination**: Mechanisms requiring global state MUST ensure access/updates don't leak any additional information.
-  State lookups SHOULD use privacy-preserving techniques.
-
-- **Sybil attacks**: For sender-generated proofs, Sybil resistance cannot be included and nodes can still perform Sybil attacks by colluding.
-  For per-hop generation, membership-based methods can provide Sybil resistance.
-
-### 9.5 Recommended Methods
-
-Specific spam protection methods fall outside this specification's scope.
-Common strategies that MAY be adapted include:
-
-- **PoW style approaches**: Approaches like [EquiHash](https://github.com/khovratovich/equihash) or [VDF Client puzzles](https://www.researchgate.net/publication/356450648_Non-Interactive_VDF_Client_Puzzle_for_DoS_Mitigation) that satisfy spam protection requirements can be used.
-  These, however, do not provide Sybil resistance, which would require a separate mechanism.
-
-- **Privacy preserving Rate-limiting**: Rate limiting approaches like [RLN](https://rate-limiting-nullifier.github.io/rln-docs/rln_in_details.html) with zero-knowledge cryptography that preserve user's privacy can be used.
-  Requires careful design of state access patterns.
-  May need to be augmented with staking and slashing to add Sybil resistance.
-
-Deployments MUST evaluate each method's computational overhead, latency impact, anonymity implications, infrastructure requirements, attack resistance, Sybil resistance, pre-computation resistance, economic cost, and architectural fit.
-
-### 9.6 Spam Protection Interface
-
-This section defines the standardized interface that spam protection mechanisms MUST implement to integrate with the Mix Protocol.
-The interface is designed to be architecture-agnostic, supporting both sender-generated proofs and Per-Hop Generated Proofs approaches described in [Section 9.2](#92-integration-architecture).
-
-Initialization and configuration of spam protection mechanisms is out of scope for this interface specification.
-Implementations are expected to handle their own initialization, configuration management, and runtime state independently before being integrated with the Mix Protocol.
-
-Any spam protection mechanism integrated with the Mix Protocol MUST provide implementations of the procedures defined in this section.
-The specific cryptographic constructions, proof systems, and verification logic are left to the mechanism's specification, but the interface signatures and the behavior defined here MUST be adhered to for interoperability.
-
-#### 9.6.1 Deployment Configuration
-
-The following parameters MUST be agreed upon and configured consistently across all nodes in a deployment:
-
-- **Proof Size**: The fixed size in bytes of `encoded_proof_data` produced by `GenerateProof`.
-  This value is used by Mix Protocol implementations to calculate header sizes and payload capacity.
-
-- **Integration Architecture**: The spam protection integration architecture used by the deployment.
-  Must be one of:
-  - `SENDER_GENERATED_PER_HOP`: Sender generates proofs for each hop (see [Section 9.6.3.1](#9631-for-sender-generated-proofs))
-  - `PER_HOP_GENERATION`: Each node generates a fresh proof for the next hop (see [Section 9.6.3.2](#9632-for-per-hop-generated-proofs))
-
-All nodes in a deployment MUST use the same integration architecture.
-Nodes MUST refuse to process packets that do not conform to the deployment's configured architecture.
-
-#### 9.6.2 Interface Procedures
-
-All spam protection mechanisms MUST implement the following procedures.
-
-##### 9.6.2.1 Proof Generation
-
-`GenerateProof(binding_data) -> encoded_proof_data`
-
-Generate a spam protection proof bound to specific packet data.
-
-**Parameters**:
-
-- `binding_data`: The packet-specific data to which the proof MAY be cryptographically bound.
-  For sender-generated proofs, this is $\delta_{i+1}$ (the decrypted payload that hop $i$ will see).
-  For per-hop generated proofs, this is the complete outgoing Sphinx packet state $(\alpha', \beta', \gamma', \delta')$.
-
-**Returns**:
-
-- `encoded_proof_data`: Serialized bytes containing the spam protection proof and any required verification metadata.
-  This is treated as opaque data by the Mix Protocol layer.
-
-**Requirements**:
-
-- The spam protection mechanism is responsible for managing its own runtime state (_e.g.,_ current epochs, difficulty levels, merkle tree states).
-  The Mix Protocol layer does not provide or track mechanism-specific runtime context.
-- The encoding MUST produce a fixed-length output, or include a length prefix if variable-length encoding is used.
-
-##### 9.6.2.2 Proof Verification
-
-`VerifyProof(encoded_proof_data, binding_data) -> valid`
-
-Verify that a spam protection proof is valid and correctly bound to the provided packet data.
-
-**Parameters**:
-
-- `encoded_proof_data`: Serialized bytes containing the spam protection proof and verification metadata, extracted from the routing block $\beta$ (for sender-generated approach) or from the packet header field $\sigma$ (for per-hop generation approach).
-- `binding_data`: The packet-specific data against which the proof SHOULD be verified.
-  For nodes verifying sender-generated proofs, this is $\delta'$ (the decrypted payload).
-  For per-hop verification, this is the received Sphinx packet state $(\alpha', \beta', \gamma', \delta')$.
-
-**Returns**:
-
-- `valid`: Boolean indicating whether the proof is valid.
-
-**Requirements**:
-
-- Implementations MUST handle malformed or truncated `encoded_proof_data` gracefully and return `false`.
-- For mechanisms that maintain global state (_e.g.,_ nullifier sets, rate-limit counters, membership trees), this procedure MUST update the internal state atomically when verification succeeds.
-  State updates (_e.g.,_ recording nullifiers, updating rate-limit counters) and state cleanup (_e.g.,_ removing expired epochs, old nullifiers) are managed internally by the spam protection mechanism.
-
-#### 9.6.3 Integration Points in Sphinx Processing
-
-The Mix Protocol invokes spam protection procedures at specific points in Sphinx packet construction and processing:
-
-##### 9.6.3.1 For Sender-Generated Proofs
-
-**Sender Nodes - During Packet Construction** ([Section 8.5.2](#852-construction-steps)):
-
-After computing encrypted payloads $\delta_i$ for each hop (Step 3.d), the sender MUST:
-
-1. For each hop $i$ in path (from $i = 0$ to $L-1$):
-   - Call `GenerateProof(binding_data = δ_{i+1})` to generate `encoded_proof_data` for hop $i$
-   - Embed the `encoded_proof_data` in hop $i$'s routing block within $\beta_i$ during header construction (Step 3.c)
-
-**Intermediate Nodes- During Packet Processing** ([Section 8.6.1](#861-shared-preprocessing)):
-
-After decrypting the routing block $\beta$ and payload $\delta'$ (Steps 4-5), the node MUST:
-
-1. Extract `encoded_proof_data` from the routing block $\beta$ at the appropriate offset
-2. Call `VerifyProof(encoded_proof_data, binding_data = δ')`
-3. If `valid = false`, discard the packet and terminate processing
-4. If `valid = true`, continue with role-specific processing (intermediary or exit)
-
-##### 9.6.3.2 For Per-Hop Generated Proofs
-
-**Entry Nodes - During Packet Construction** ([Section 8.5.2](#852-construction-steps)):
-
-After assembling the final Sphinx packet (Step 3.e), the entry node MUST:
-
-1. Call `GenerateProof(binding_data)` where `binding_data` is the complete Sphinx packet bytes
-2. Append `encoded_proof_data` after the Sphinx packet and send to the first hop
-
-**Intermediate Nodes - During Packet Processing** ([Section 8.6](#86-sphinx-packet-handling)):
-
-**Before** any Sphinx decryption operations, intermediate nodes MUST:
-
-1. Extract `encoded_proof_data` from the last `proofSize` bytes of the received packet
-2. Call `VerifyProof(encoded_proof_data, binding_data)` where `binding_data` is the Sphinx packet bytes
-3. If the proof is not valid, discard the packet and terminate processing immediately
-4. If valid, perform standard Sphinx processing, then call `GenerateProof(binding_data)` with the transformed packet as `binding_data`
-5. Append the new `encoded_proof_data` to the transformed Sphinx packet and forward
-
-**Exit nodes** follow steps 1-3 but do not generate a new proof.
-
-## 10. Security Considerations
+## 9. Security Considerations
 
 This section describes the security guarantees and limitations of the Mix Protocol.
 It begins by outlining the anonymity properties provided by the core protocol when routing messages through the mix network.
 It then discusses the trust assumptions required at the edges of the network, particularly at the final hop.
 Finally, it presents an alternative trust model for destinations that support Mix Protocol directly, followed by a summary of broader limitations and areas that may be addressed in future iterations.
 
-### 10.1 Security Guarantees of the Core Mix Protocol
+### 9.1 Security Guarantees of the Core Mix Protocol
 
 The core Mix Protocol&mdash;comprising anonymous routing through a sequence of mix nodes using Sphinx packets&mdash;provides the following security guarantees:
 
@@ -1531,14 +1233,14 @@ These guarantees hold only within the boundaries of the Mix Protocol.
 Additional trust assumptions are introduced at the edges, particularly at the final hop, where the decrypted message is handed off to the Mix Exit Layer for delivery to the destination outside the mixnet.
 The next subsection discusses these trust assumptions in detail.
 
-### 10.2 Exit Node Trust Model
+### 9.2 Exit Node Trust Model
 
 The Mix Protocol ensures strong sender anonymity and metadata protection between the Mix Entry and Exit layers.
 However, once a Sphinx packet is decrypted at the final hop, additional trust assumptions are introduced.
 The node processing the final layer of encryption is trusted to forward the correct message to the destination and return any reply using the provided reply key.
 This section outlines the resulting trust boundaries.
 
-#### 10.2.1 Message Delivery and Origin Trust
+#### 9.2.1 Message Delivery and Origin Trust
 
 At the final hop, the decrypted Sphinx packet reveals the plaintext message and destination address.
 The exit node is then trusted to deliver this message to the destination application, and&mdash;if a reply is expected&mdash;to return the response using the embedded reply key.
@@ -1564,7 +1266,7 @@ That is, the exit remains a necessary point of trust for message delivery and re
 The next subsection describes a related limitation:
 the exit's ability to pose as a legitimate client to the destination's origin protocol, and how that can be abused to bypass application-layer expectations.
 
-#### 10.2.2 Origin Protocol Trust and Client Role Abuse
+#### 9.2.2 Origin Protocol Trust and Client Role Abuse
 
 In addition to the message delivery and origin trust assumption, the exit node also initiates a client-side connection to the origin protocol instance at the destination.
 From the destination's perspective, this appears indistinguishable from a conventional peer connection, and the exit is accepted as a legitimate peer.
@@ -1584,7 +1286,7 @@ It allows applications to preserve sender anonymity without requiring any partic
 However, in scenarios that demand stronger end-to-end guarantees&mdash;such as verifiable message delivery, origin authentication, or control over client access&mdash;it may be beneficial for the destination itself to operate a Mix instance.
 This alternative model is described in the next subsection.
 
-### 10.3 Destination as Final Hop
+### 9.3 Destination as Final Hop
 
 In some deployments, it may be desirable for the destination node to participate in the Mix Protocol directly.
 In this model, the destination operates its own Mix instance and is selected as the final node in the mix path.
@@ -1611,13 +1313,13 @@ Additional details on discovery configurations are out of scope for this specifi
 
 This trust model is not required for interoperability, but is recommended when assessing deployment-specific threat models, especially in protocols that require message integrity or authenticated replies.
 
-### 10.4 Known Protocol Limitations
+### 9.4 Known Protocol Limitations
 
 The Mix Protocol provides strong sender anonymity and metadata protection guarantees within the mix network.
 However, it does not address all classes of network-level disruption or application-layer abuse.
 This section outlines known limitations that deployments MUST consider when evaluating system resilience and reliability.
 
-#### 10.4.1 Undetectable Node Misbehavior
+#### 9.4.1 Undetectable Node Misbehavior
 
 The Mix Protocol in its current version does not include mechanisms to detect or attribute misbehavior by mix nodes.
 Since Sphinx packets are unlinkable and routing is stateless, malicious or faulty nodes may delay, drop, or selectively forward packets without detection.
@@ -1629,13 +1331,13 @@ As a result, unreliable nodes cannot be penalized or excluded based on observed 
 Future versions may explore accountability mechanisms.
 For now, deployments MAY improve robustness by sending each packet along multiple paths as defined in [Section X.X], but MUST treat message loss as a possibility.
 
-#### 10.4.2 No Built-in Retry or Acknowledgment
+#### 9.4.2 No Built-in Retry or Acknowledgment
 
 The Mix protocol does not support retransmission, delivery acknowledgments, or automated fallback logic.
 Each message is sent once and routed independently through the mixnet.
 If a message is lost or a node becomes unavailable, recovery is the responsibility of the top-level application.
 
-Single-Use Reply Blocks (SURBs) (defined in Section[X.X]) enable destinations to send responses back to the sender via a fresh mix path.
+Single-Use Reply Blocks (SURBs) (defined in [Section X.X]) enable destinations to send responses back to the sender via a fresh mix path.
 However, SURBs are optional, and their usage for acknowledgments or retries must be coordinated by the application.
 
 Applications using the Mix Protocol MUST treat delivery as probabilistic.
@@ -1646,7 +1348,7 @@ To improve reliability, the sender MAY:
 
 These strategies MUST be implemented at the origin protocol layer or through Mix integration logic and are not enforced by the Mix Protocol itself.
 
-#### 10.4.3 No Sybil Resistance
+#### 9.4.3 No Sybil Resistance
 
 The Mix Protocol does not include any built-in defenses against Sybil attacks.
 All nodes that support the protocol and are discoverable via peer discovery are equally eligible for path selection.
@@ -1658,9 +1360,10 @@ This raises the risk of deanonymization through end-to-end traffic correlation o
 Deployments concerned with Sybil resistance MAY implement passive defenses such as minimum path length constraints.
 More advanced mitigations such as stake-based participation or resource proofs typically require some form of trusted setup or blockchain-based coordination.
 
-Such defenses are out of scope in the current version of the Mix Protocol, but are critical to ensuring anonymity at scale and may be explored in future iterations.
+Such defenses are not built into the current version of the Mix Protocol, but are critical to ensuring anonymity at scale.
+Deployments that enable DoS protection (see [Section 6.6](#66-dos-protection)) may gain Sybil resistance as a side effect, depending on the approach chosen.
 
-#### 10.4.4 Vulnerability to Denial-of-Service Attacks
+#### 9.4.4 Vulnerability to Denial-of-Service Attacks
 
 The Mix Protocol does not provide built-in defenses against denial-of-service (DoS) attacks targeting mix nodes.
 A malicious mix node may generate a high volume of valid Sphinx packets to exhaust computational, memory, or bandwidth resources along random paths through the network.
@@ -1669,13 +1372,9 @@ This risk stems from the protocol's stateless and sender-anonymous design.
 Mix nodes process each packet independently and cannot distinguish honest users from attackers.
 There is no mechanism to attribute packets, limit per-sender usage, or apply network-wide fairness constraints.
 
-Mix nodes remain vulnerable to volumetric attacks even when destinations are protected.
-
 While the Mix Protocol includes safeguards such as layered encryption, per-hop integrity checks, and fixed-size headers, these primarily defend against tagging attacks and structurally invalid or malformed traffic.
 The Sphinx packet format also enforces a maximum path length $(L \leq r)$, which prevents infinite loops or excessively long paths being embedded.
 However, these protections do not prevent adversaries from injecting large volumes of short, well-formed messages to exhaust mix node resources.
 
-DoS protection&mdash;such as admission control, rate-limiting, or resource-bound access&mdash;can be plugged in as explained in [Spam protection](#63-spam-protection).
+DoS protection&mdash;such as admission control, rate-limiting, or resource-bound access&mdash;can be plugged in as explained in [Section 6.6](#66-dos-protection).
 Any such mechanism MUST preserve sender unlinkability and SHOULD be evaluated carefully to avoid introducing correlation risks.
-
-Defending against large-scale DoS attacks is considered a deployment-level responsibility and is out of scope for this specification.

--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -648,7 +648,7 @@ Payload &= 4608 - 624 \\
 `$
 
 Implementations MUST account for payload extensions, such as SURBs, when determining the maximum message size that can be encapsulated in a single Sphinx packet.
-Details on SURBs are defined in [Section X.X].
+Details on SURBs are defined in [Section 8.7.1](#871-surb-component-sizes).
 
 The following subsection defines the padding and fragmentation requirements for ensuring this fixed-size constraint.
 
@@ -739,7 +739,7 @@ The construction MUST proceed as follows:
 
    - Apply any configured exit abuse prevention mechanism (_e.g.,_ PoW, VDF, RLN) to the serialized message.
    Exit abuse prevention mechanisms are pluggable as defined in [Section 6.3](#63-exit-abuse-prevention).
-   - Attach one or more SURBs, if required. Their format and processing are specified in [Section X.X].
+   - Attach one or more SURBs, if required, following the steps in [Section 8.7.2](#872-surb-creation).
    - Append the origin protocol codec in a format that enables the exit node to reliably extract it during parsing. A recommended encoding approach is to prefix the codec string with its length, encoded as a compact varint field limited to two bytes. Regardless of the scheme used, implementations MUST agree on the format within a deployment to ensure deterministic decoding.
    - Pad the result to the maximum application message length of $3968$ bytes using a deterministic padding scheme. This value is derived from the fixed payload size in [Section 8.3.2](#832-payload-size) ($3984$ bytes) minus the security parameter $κ = 16$ bytes defined in [Section 8.2](#82-cryptographic-primitives). The chosen scheme MUST yield a fixed-size padded output and MUST be consistent across all mix nodes to ensure correct interpretation during unpadding. For example, schemes that explicitly encode the padding length and prepend zero-valued padding bytes MAY be used.
    - Let the resulting message be $m$.
@@ -932,7 +932,7 @@ The construction MUST proceed as follows:
 
    f. **Transmit Packet**
 
-   - Sample a randomized delay from the same distribution family used for per-hop delays (in Step 3.c.) with an independently chosen mean.
+   - Sample a randomized delay from the same distribution family used for per-hop delays (in step 3.c.) with an independently chosen mean.
 
    This delay prevents timing correlation when multiple Sphinx packets are sent in quick succession.
    Such bursts may occur when an upstream protocol fragments a large message, or when several messages are sent close together.
@@ -1057,7 +1057,7 @@ As described in [Section 8.6.1](#861-shared-preprocessing), the mix node obtains
 
 At this stage, the node MUST determine whether it is an intermediary or the exit based on the prefix of $B$, in accordance with the construction of $β_i$ defined in [Section 8.5.2](#852-construction-steps) step 3.c.:
 
-- If the first $(tκ - 2)$ bytes of $B$ contain a nonzero-encoded address immediately followed by a two-byte zero delay, process the packet as an exit.
+- If $B_{[(tκ-2)\ldots tκ-1]}$ contains a two-byte zero delay, process the packet as an exit.
 - Otherwise, process the packet as an intermediary.
 
 The following subsections define the precise behavior for each case.
@@ -1078,7 +1078,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
      \end{array}
      `$
 
-   - Extract next two bytes as the mean delay $\mathrm{delay}$
+   - Extract the next two bytes as the mean delay $\mathrm{delay}$
 
      $`
      \begin{array}{l}
@@ -1086,7 +1086,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
      \end{array}
      `$
 
-   - Extract next $κ$ bytes as the next hop MAC $γ'$
+   - Extract the next $κ$ bytes as the next hop MAC $γ'$
 
      $`
      \begin{array}{l}
@@ -1094,7 +1094,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
      \end{array}
      `$
 
-   - Extract next $(r(t+1)+1)κ$ bytes as the next hop routing information $β'$
+   - Extract the next $(r(t+1)+1)κ$ bytes as the next hop routing information $β'$
 
      $`
      \begin{array}{l}
@@ -1108,7 +1108,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
 
    Update the header fields according to the construction steps defined in [Section 8.5.2](#852-construction-steps):
 
-   - Compute the next hop ephemeral public value $α'$, deriving the blinding factor $b$ from the shared secret $s$ computed in [Section 8.6.1](#861-shared-preprocessing) step 1.
+   - Compute the next hop ephemeral public value $α'$, deriving the blinding factor $b$ from the shared secret $s$ computed in [Section 8.6.1](#861-shared-preprocessing) Step 1.
 
      $`
      \begin{aligned}
@@ -1121,7 +1121,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
 
 3. **Update Payload**
 
-   Use the decrypted payload $δ'$ computed in [Section 8.6.1](#861-shared-preprocessing) step 5. as the payload in the outgoing packet.
+   Use the decrypted payload $δ'$ computed in [Section 8.6.1](#861-shared-preprocessing) Step 5. as the payload in the outgoing packet.
 
 4. **Assemble Final Packet**
    The final Sphinx packet is structured as defined in [Section 8.3](#83-packet-component-sizes):
@@ -1138,7 +1138,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
 
 5. **Transmit Packet**
 
-   - Interpret the $\mathrm{addr}$ and $\mathrm{delay}$ extracted in Step 1. according to the encoding format used during construction in [Section 8.5.2](#852-construction-steps) Step 3.c.
+   - Interpret the $\mathrm{addr}$ and $\mathrm{delay}$ extracted in Step 1. according to the encoding format used during construction in [Section 8.5.2](#852-construction-steps) step 3.c.
 
    - Sample the actual forwarding delay from the configured delay distribution, using the decoded mean delay value as the distribution parameter.
 
@@ -1154,13 +1154,19 @@ Once the node determines its role as an intermediary following the steps in [Sec
 
 #### 8.6.4 Exit Processing
 
-Once the node determines its role as an exit following the steps in [Section 8.6.2](#862-node-role-determination), it MUST perform the following steps to interpret routing block $B$ and decrypted payload $δ'$ obtained in [Section 8.6.1](#861-shared-preprocessing):
+Once the node determines its role as an exit following the steps in [Section 8.6.2](#862-node-role-determination), it MUST determine the exit message type from the routing block $B$ obtained in [Section 8.6.1](#861-shared-preprocessing):
+
+- If $B_{[0 \ldots tκ-3]}$ encodes zero address and $B_{[tκ \ldots tκ+κ-1]}$ is nonzero (_i.e.,_ contains a SURB identifier), the packet is a SURB reply.
+  Process per [Section 8.7.4](#874-surb-reply-processing).
+
+- Otherwise, the packet is a forward message.
+  The node MUST perform the following steps to interpret routing block $B$ and decrypted payload $δ'$ obtained in [Section 8.6.1](#861-shared-preprocessing):
 
 1. **Parse Routing Block**
 
    Parse the routing block $B$ according to the $β_i$, $i = L - 1$ construction defined in [Section 8.5.2](#852-construction-steps) step 3.c.:
 
-   - Extract first $(tκ - 2)$ bytes of $B$ as the destination address $Δ$
+   - Extract the first $(tκ - 2)$ bytes of $B$ as the destination address $Δ$
 
      $`
      \begin{array}{l}
@@ -1170,7 +1176,7 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
 2. **Recover Padded Application Message**
 
-   - Verify the decrypted payload $δ'$ computed in [Section 8.6.1](#861-shared-preprocessing) step 5.:
+   - Verify the decrypted payload $δ'$ computed in [Section 8.6.1](#861-shared-preprocessing) Step 5.:
 
      $`
      \begin{array}{l}
@@ -1192,7 +1198,7 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
 3. **Extract Application Message**
 
-   Interpret recovered $m$ according to the construction steps defined in [Section 8.5.2](#852-construction-steps) step 1.:
+   Interpret recovered $m$ according to the construction steps defined in [Section 8.5.2](#852-construction-steps) Step 1.:
 
    - First, unpad $m$ using the deterministic padding scheme defined during construction.
 
@@ -1210,9 +1216,212 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
 4. **Handoff to Exit Layer**
 
-   - Hand off the serialized application message, the origin protocol codec, and destination address $Δ$ (extracted in step 1.) to the local Exit layer for further processing and delivery.
+   - Hand off the serialized application message, the origin protocol codec, destination address $Δ$ (extracted in Step 1.), and any SURBs extracted in Step 3. to the local Exit Layer for further processing and delivery.
 
    - The Exit Layer is responsible for establishing a client-only connection and forwarding the message to the destination. Implementations MAY reuse an existing stream to the destination, if doing so does not introduce any observable linkability between forwarded messages.
+     It is also responsible for storing any received SURBs and routing responses from the destination using them (see [Section 8.7.3](#873-using-a-surb)).
+
+### 8.7 Single-Use Reply Blocks
+
+A Single-Use Reply Block (SURB) allows the recipient of a Sphinx packet to send a reply without learning the sender's identity, the return mix path, or any forwarding delays.
+
+A SURB MUST be used at most once. Reusing a SURB allows nodes on the return path to link multiple replies back to the original sender.
+
+A SURB encodes a complete Sphinx header for a return path, a symmetric reply key, and a unique reply identifier. The initiating node constructs one or more SURBs and embeds them in the outgoing Sphinx packet payload. The recipient uses a SURB to reply — only the original sender can decrypt the reply.
+
+This section defines how SURBs are created ([Section 8.7.2](#872-surb-creation)), used by the recipient ([Section 8.7.3](#873-using-a-surb)), processed by the exit node ([Section 8.7.4](#874-surb-reply-processing)), and recovered by the Exit Layer ([Section 8.7.5](#875-reply-recovery)).
+
+#### 8.7.1 SURB Component Sizes
+
+A SURB consists of the following components:
+
+- **$\mathrm{hop}_0$**: $tκ - 2$ bytes. The address of the first mix node on the return path, encoded as defined in [Section 8.4](#84-address-and-delay-encoding).
+- **$(α_0, β_0, γ_0)$**: A complete Sphinx header for the return path, with component sizes as defined in [Section 8.3.1](#831-header-field-sizes):
+  - $α_0$: $32$ bytes
+  - $β_0$: $(r(t + 1) + 1)κ$ bytes
+  - $γ_0$: $κ$ bytes
+- **$\tilde{k}$**: $κ$ bytes. The reply key.
+
+The total SURB size is:
+
+$`
+\begin{aligned}
+|SURB| &= (tκ - 2) + 32 + (r(t + 1) + 1)κ + κ + κ \\
+       &= 30 + (r(t + 1) + 3)κ + tκ
+\end{aligned}
+`$
+
+Using the recommended parameters ($r = 5$, $t = 6$, $κ = 16$ bytes):
+
+$`
+\begin{aligned}
+|SURB| &= 94 + 32 + 576 + 16 + 16 \\
+       &= 734\ \text{bytes}
+\end{aligned}
+`$
+
+Each SURB embedded in the message payload reduces the available application message space by $734$ bytes. With the allowable message size of $3968$ bytes derived in [Section 8.5.2](#852-construction-steps) step 3.d, attaching $n$ SURBs leaves $3968 - (n \times 734)$ bytes for the application message, protocol codec, and any exit abuse prevention proof.
+
+#### 8.7.2 SURB Creation
+
+Depending on whether an application message requires a reply, the initiating node may create and attach one or more SURBs during its preparation ([Section 8.5.2](#852-construction-steps) Step 1) for Sphinx packet construction.
+To construct each SURB, the initiating node MUST perform the following steps:
+
+1. **Select Return Path and Compute Ephemeral Secrets**
+
+   Select a return mix path of length $L \geq 3$ with the initiating node as the final hop. Compute the ephemeral public value $α_0$ and per-hop shared secrets $s_0, \ldots, s_{L-1}$ following the same procedure as [Section 8.5.2](#852-construction-steps) Step 2 and step 3.a.
+
+2. **Sample SURB Identifier and Reply Key**
+
+   Sample a unique SURB identifier $\mathrm{id}$ and a reply key $\tilde{k}$ of length $κ$ bytes uniformly at random.
+
+3. **Construct Return Path Header**
+
+   Compute per-hop filler strings and construct the routing header following the same procedure in [Section 8.5.2](#852-construction-steps) steps 3.b and 3.c, with just $β_{L-1}$ computed as follows:
+
+   $`
+   \begin{array}{l}
+   β_{L-1} = \mathrm{AES\text{-}CTR}\bigl(β_{\mathrm{aes\_key}_{L-1}},\;
+   β_{\mathrm{iv}_{L-1}},\;
+   0_{tκ} \mid \mathrm{id} \mid 0_{(((t+1)(r-L))+1)κ}
+   \bigr) \bigm| Φ_{L-1}
+   \end{array}
+   `$
+
+   That is, encode zero address and delay followed by the SURB identifier $\mathrm{id}$ in $β_{L-1}$. The SURB identifier is embedded so that the initiating node can match an incoming reply to the stored decryption keys in Step 4 below.
+
+   Use the same construction for the remaining routing blocks $β_i$, $0 \leq i < L-1$, and all per-hop MACs $γ_i$, $0 \leq i \leq L-1$.
+
+   Note: A SURB construction follows the same steps for Sphinx packet construction in [Section 8.5.2](#852-construction-steps) Steps 2 and 3, with a modified exit routing block that signals a SURB reply.
+
+4. **Assemble SURB**
+
+   Assemble the SURB tuple $\mathrm{hop}_0,\; (α_0, β_0, γ_0),\; \tilde{k}$ as defined in [Section 8.7.1](#871-surb-component-sizes). Here $\mathrm{hop}_0$ is the address of the first hop on the return path. Embed the SURB in the message payload.
+
+   The initiating node MUST store the tuple $(\tilde{k},\; s_0,\; \ldots,\; s_{L-1})$ in a local table indexed by $\mathrm{id}$, for reply recovery defined in [Section 8.7.5](#875-reply-recovery).
+
+#### 8.7.3 Using a SURB
+
+When the Exit Layer receives any SURBs as part of the handoff defined in [Section 8.6.4](#864-exit-processing) Step 4, it MUST retain them for routing the destination's responses back to the sender.
+
+Note: Each retained SURB consists of the hop address of the first node in the return path, a pre-computed Sphinx header, and a reply key, as defined in [Section 8.7.1](#871-surb-component-sizes).
+
+Once the destination responds with a reply message, the Exit Layer MUST perform the following steps to use a SURB $(\mathrm{hop}_0,\; (α, β, γ),\; \tilde{k})$:
+
+1. **Prepare Reply Message**
+
+   Pad the reply message to $3968$ bytes using a deterministic padding scheme, consistent with [Section 8.5.2](#852-construction-steps) Step 1. Let the resulting message be $m$.
+
+2. **Encrypt Reply Payload**
+
+   Derive the AES key, IV, and compute the encrypted payload $δ$ following the same procedure in [Section 8.5.2](#852-construction-steps) step 3.d for $i = L-1$, substituting $\tilde{k}$ for $s_{L-1}$.
+
+   Note: Unlike the forward path ([Section 8.5.2](#852-construction-steps) step 3.d), the reply payload is encrypted only once&mdash;using $\tilde{k}$ alone. Each mix node on the return path will apply one additional layer during Sphinx processing ([Section 8.6.1](#861-shared-preprocessing) Step 5), resulting in $L + 1$ layers total that the initiating node must remove during reply recovery (see [Section 8.7.5](#875-reply-recovery)).
+
+3. **Assemble and Transmit Reply Packet**
+
+   Assemble the Sphinx packet using the SURB header $(α, β, γ)$ and encrypted payload $δ$ from Step 2, following the packet format defined in [Section 8.5.2](#852-construction-steps) step 3.e. Serialize and transmit packet to $\mathrm{hop}_0$ (retrieved from the SURB) via a libp2p stream negotiated under the `"/mix/1.0.0"` protocol identifier.
+
+#### 8.7.4 SURB Reply Processing
+
+During Sphinx packet handling, once a node determines its role as an exit following the steps in [Section 8.6.2](#862-node-role-determination) and the message type as SURB reply from [Section 8.6.4](#864-exit-processing), it MUST perform the following steps to interpret the routing block $B$ and decrypted payload $δ'$ obtained in [Section 8.6.1](#861-shared-preprocessing):
+
+1. **Extract SURB Identifier**
+
+   Extract the SURB identifier $\mathrm{id}$ from $B$, at the position defined in [Section 8.7.2](#872-surb-creation) Step 3:
+
+   $`
+   \begin{array}{l}
+   \mathrm{id} = B_{[tκ\ldots tκ+κ-1]}
+   \end{array}
+   `$
+
+2. **Handoff to Exit Layer**
+
+   Hand off the decrypted payload $δ'$ and the extracted SURB identifier $\mathrm{id}$ to the local Exit Layer for reply recovery, as defined in [Section 8.7.5](#875-reply-recovery).
+
+#### 8.7.5 Reply Recovery
+
+When the Exit Layer receives decrypted payload $δ'$ and the SURB identifier $\mathrm{id}$, as part of the handoff defined in [Section 8.7.4](#874-surb-reply-processing) Step 2, it MUST perform the following steps to recover the reply message:
+
+1. **Retrieve Decryption Keys**
+
+   Retrieve the decryption keys tuple $(\tilde{k},\; s_0,\; \ldots,\; s_{L-1})$ indexed by $\mathrm{id}$ stored as defined in [Section 8.7.2](#872-surb-creation) Step 4.
+   
+   If no tuple is found, discard the reply and terminate processing.
+
+2. **Recover Padded Reply Message**
+
+   The encrypted payload $δ'$ contains the padded reply message $m$ defined in [Section 8.7.3](#873-using-a-surb) Step 1, prepended with a $κ$-byte string of zeros.
+   It is encrypted in $L + 1$ layers&mdash;first using the reply key $\tilde{k}$, then with each hop on the return path adding exactly one layer using the per-hop session key $s_0,\; \ldots,\; s_{L-1}$.
+   To recover the padded reply message, perform the following steps for each layer $i = 0$ to $L$, recursively:
+
+   - Derive per-hop AES key and IV:
+
+     - If $i = 0$ (_i.e.,_ first layer):
+
+       $`
+       \begin{array}{l}
+       δ_{\mathrm{aes\_key}_i} = \mathrm{KDF}(\text{"δ\_aes\_key"} \mid \tilde{k})\\
+       δ_{\mathrm{iv}_i} =
+       \mathrm{KDF}(\text{"δ\_iv"} \mid \tilde{k})
+       \end{array}
+       `$
+
+     - If $i = 1$ to $L$ (_i.e.,_ all other layers):
+
+       $`
+       \begin{array}{l}
+       δ_{\mathrm{aes\_key}_i} = \mathrm{KDF}(\text{"δ\_aes\_key"} \mid s_{i-1})\\
+       δ_{\mathrm{iv}_i} =
+       \mathrm{KDF}(\text{"δ\_iv"} \mid s_{i-1})
+       \end{array}
+       `$
+
+   - Using the derived keys, decrypt $δ'$:
+
+     - If $i = 0$ (_i.e.,_ first layer):
+
+       $`
+       \begin{array}{l}
+       δ_i = \mathrm{AES\text{-}CTR}\bigl(δ_{\mathrm{aes\_key}_i},
+       δ_{\mathrm{iv}_i}, δ'
+       \bigr)
+       \end{array}
+       `$
+
+     - If $i = 1$ to $L$ (_i.e.,_ all other layers):
+
+       $`
+       \begin{array}{l}
+       δ_i = \mathrm{AES\text{-}CTR}\bigl(δ_{\mathrm{aes\_key}_i},
+       δ_{\mathrm{iv}_i}, δ_{i-1} \bigr)
+       \end{array}
+       `$
+
+   - Verify the decrypted payload $δ_{L}$:
+
+     $`
+     \begin{array}{l}
+     δ_L{}_{[0\ldots{κ} - 1]} \stackrel{?}{=} 0_{κ}
+     \end{array}
+     `$
+
+     If the check fails, discard $δ_{L}$ and terminate processing.
+
+3. **Recover Reply Message**
+
+   - Extract rest of the bytes of $δ_{L}$ as the padded reply message $m$:
+
+     $`
+     \begin{array}{l}
+     m = δ_L{}_{[κ\ldots]}
+     \end{array}
+     `$
+
+   - Unpad $m$ using the deterministic padding scheme defined during construction in [Section 8.7.3](#873-using-a-surb) Step 1.
+  
+   - Erase all temporary values and the stored decryption keys $(\tilde{k},\; s_0,\; \ldots,\; s_{L-1})$ from memory.
 
 ## 9. Security Considerations
 
@@ -1339,7 +1548,7 @@ The Mix Protocol does not support retransmission, delivery acknowledgments, or a
 Each message is sent once and routed independently through the mixnet.
 If a message is lost or a node becomes unavailable, recovery is the responsibility of the top-level application.
 
-Single-Use Reply Blocks (SURBs) (defined in [Section X.X]) enable destinations to send responses back to the sender via a fresh mix path.
+Single-Use Reply Blocks (SURBs) (defined in [Section 8.7](#87-single-use-reply-blocks)) enable destinations to send responses back to the sender via a fresh mix path.
 However, SURBs are optional, and their usage for acknowledgments or retries must be coordinated by the application.
 
 Applications using the Mix Protocol MUST treat delivery as probabilistic.

--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -2,11 +2,11 @@
 
 | Field | Value |
 | --- | --- |
-| Name | LIBP2P-MIX|
+| Name | LIBP2P-MIX |
 | Slug | 99 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Akshaya Mani <akshaya@status.im>|
+| Editor | Akshaya Mani <akshaya@status.im> |
 | Contributors | Prem Prathi <prem@status.im>, Daniel Kaiser <danielkaiser@status.im>, Hanno Cornelius |
 
 <!-- timeline:start -->
@@ -182,7 +182,7 @@ Together with a constant-size header and payload, this provides bounded protecti
 
 It also supports anonymous and indistinguishable reply messages through [Single-Use Reply Blocks (SURBs)](https://cypherpunks.ca/~iang/pubs/Sphinx_Oakland09.pdf), although reply support is not implemented yet.
 
-A complete specification of the Sphinx packet structure and fields is provided in [Section 6].
+A complete specification of the Sphinx packet structure and fields is provided in [Section 8](#8-sphinx-packet-format).
 
 ## 5. Protocol Overview
 
@@ -272,7 +272,7 @@ The destination node does not need to support the Mix Protocol to receive or res
 
 The behavior described above represents the core Mix Protocol.
 In addition, the protocol supports a set of pluggable components that extend its functionality.
-These components cover areas such as node discovery, delay strategy, spam resistance, cover traffic generation, and incentivization.
+These components cover areas such as node discovery, delay strategy, exit abuse prevention, cover traffic generation, incentivization, and DoS protection.
 Some are REQUIRED for interoperability; others are OPTIONAL or deployment-specific.
 The next section describes each component.
 
@@ -313,7 +313,7 @@ To enable this, regardless of the discovery mechanism used, each mix node MUST m
 - Its X25519 public key for Sphinx encryption.
 - One or more routable libp2p multiaddresses that identify the mix node's own network endpoints.
 
-To support sender anonymity at scale, discovery mechanism SHOULD support _unbiased random sampling_ from the set of live mix nodes.
+To support sender anonymity at scale, the discovery mechanism SHOULD support _unbiased random sampling_ from the set of live mix nodes.
 This enables diverse path construction and reduces exposure to adversarial routing bias.
 
 While no existing mechanism provides unbiased sampling by default, [Waku's ambient discovery](https://rfc.vac.dev/waku/standards/core/33/discv5/)&mdash;an extension over [Discv5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md)&mdash;demonstrates an approximate solution.
@@ -442,7 +442,7 @@ To perform message initiation, a mix node MUST:
 
 - Select a random mix path.
 - Assign a delay value for each hop and encode it into the Sphinx packet header.
-- Wrap message in a Sphinx packet by applying layered encryption in reverse order of nodes in the selected mix path.
+- Wrap the message in a Sphinx packet by applying layered encryption in reverse order of nodes in the selected mix path.
 - Forward the resulting packet to the first mix node in the mix path using the Mix Protocol.
 
 The Mix Protocol does not interpret message content or origin protocol context.
@@ -530,7 +530,7 @@ This section defines the cryptographic primitives used in Sphinx packet construc
 
   - **Curve**: Curve25519
   - **Notation**: Let $g$ denote the canonical base point (generator) of $\mathbb{G}$.
-  - **Purpose**: Used for deriving Diffie–Hellman-style shared key at each hop using $α$.
+  - **Purpose**: Used for deriving a Diffie–Hellman-style shared key at each hop using $α$.
   - **Representation**: Small 32-byte group elements, efficient for both encryption and key exchange.
   - **Scalar Field**: The curve is defined over the finite field $\mathbb{Z}_q$, where $q = 2^{252} + 27742317777372353535851937790883648493$. Ephemeral exponents used in Sphinx packet construction are selected uniformly at random from $\mathbb{Z}_q^*$, the multiplicative subgroup of $\mathbb{Z}_q$.
 
@@ -600,7 +600,7 @@ Thus, the total header length is:
 $`
 \begin{aligned}
 |Header| &= α + β + γ \\
-  &= 32 + ((t + 1)r + 1)κ + 16
+  &= 32 + (r(t + 1) + 1)κ + 16
 \end{aligned}
 `$
 
@@ -834,7 +834,7 @@ The construction MUST proceed as follows:
 
    - Set the per hop two-byte encoded delay $\mathrm{delay}_i$ as defined in [Section 8.4](#84-address-and-delay-encoding):
 
-     - If final hop (_i.e.,_ $i = L - 1$), encode two byte zero padding.
+     - If final hop (_i.e.,_ $i = L - 1$), encode two-byte zero padding.
      - For all other hop $i$, $i < L - 1$, select the mean forwarding delay for the delay strategy configured by the application, and encode it as a two-byte value. The delay strategy is pluggable, as defined in [Section 6.2](#62-delay-strategy).
 
    - Using the derived keys and encoded forwarding delay, compute the nested encrypted routing information $β_i$:
@@ -1096,7 +1096,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
 
      $`
      \begin{array}{l}
-     β' = B_{[(t + 1)κ\ldots(r(t +1 ) + t + 2)κ - 1]}
+     β' = B_{[(t + 1)κ\ldots(r(t + 1) + t + 2)κ - 1]}
      \end{array}
      `$
 
@@ -1224,7 +1224,7 @@ Finally, it presents an alternative trust model for destinations that support Mi
 The core Mix Protocol&mdash;comprising anonymous routing through a sequence of mix nodes using Sphinx packets&mdash;provides the following security guarantees:
 
 - **Sender anonymity**: Each message is wrapped in layered encryption and routed independently, making it unlinkable to the sender even if multiple mix nodes are colluding.
-- **Metadata protection**: All messages are fixed in size and indistinguishable on the wire. Sphinx packets reveal only the immediate next hop and delay to each mix node. No intermediate node learns its position in the path or the total pathlength.
+- **Metadata protection**: All messages are fixed in size and indistinguishable on the wire. Sphinx packets reveal only the immediate next hop and delay to each mix node. No intermediate node learns its position in the path or the total path length.
 - **Traffic analysis resistance**: Continuous-time mixing with randomized per-hop delays reduces the risk of timing correlation and input-output linkage.
 - **Per-hop confidentiality and integrity**: Each hop decrypts only its assigned layer of the Sphinx packet and verifies header integrity via a per-hop MAC.
 - **No long-term state**: All routing is stateless. Mix nodes do not maintain per-message metadata, reducing the surface for correlation attacks.
@@ -1333,7 +1333,7 @@ For now, deployments MAY improve robustness by sending each packet along multipl
 
 #### 9.4.2 No Built-in Retry or Acknowledgment
 
-The Mix protocol does not support retransmission, delivery acknowledgments, or automated fallback logic.
+The Mix Protocol does not support retransmission, delivery acknowledgments, or automated fallback logic.
 Each message is sent once and routed independently through the mixnet.
 If a message is lost or a node becomes unavailable, recovery is the responsibility of the top-level application.
 

--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -1229,18 +1229,20 @@ A SURB MUST be used at most once. Reusing a SURB allows nodes on the return path
 
 A SURB encodes a complete Sphinx header for a return path, a symmetric reply key, and a unique reply identifier. The initiating node constructs one or more SURBs and embeds them in the outgoing Sphinx packet payload. The recipient uses a SURB to reply — only the original sender can decrypt the reply.
 
-This section defines how SURBs are created ([Section 8.7.2](#872-surb-creation)), used by the recipient ([Section 8.7.3](#873-using-a-surb)), processed by the exit node ([Section 8.7.4](#874-surb-reply-processing)), and recovered by the Exit Layer ([Section 8.7.5](#875-reply-recovery)).
+This section defines SURB component sizes and total size ([Section 8.7.1](#871-surb-component-sizes)), how SURBs are created ([Section 8.7.2](#872-surb-creation)), used by the recipient ([Section 8.7.3](#873-using-a-surb)), processed by the exit node ([Section 8.7.4](#874-surb-reply-processing)), and recovered by the Exit Layer ([Section 8.7.5](#875-reply-recovery)).
 
 #### 8.7.1 SURB Component Sizes
 
 A SURB consists of the following components:
 
-- **$\mathrm{hop}_0$**: $tκ - 2$ bytes. The address of the first mix node on the return path, encoded as defined in [Section 8.4](#84-address-and-delay-encoding).
+- **$\mathrm{hop}_0$**: $tκ - 2$ bytes. The address of the first mix node on the return path. Uses the same $tκ$ address block encoding defined in [Section 8.4](#84-address-and-delay-encoding), minus the 2-byte delay field, since no delay is encoded here.
+
 - **$(α_0, β_0, γ_0)$**: A complete Sphinx header for the return path, with component sizes as defined in [Section 8.3.1](#831-header-field-sizes):
-  - $α_0$: $32$ bytes
-  - $β_0$: $(r(t + 1) + 1)κ$ bytes
-  - $γ_0$: $κ$ bytes
-- **$\tilde{k}$**: $κ$ bytes. The reply key.
+  - $α_0$: $32$ bytes. The ephemeral public value for the first hop.
+  - $β_0$: $(r(t + 1) + 1)κ$ bytes.  The nested encrypted routing information for the return path.
+  - $γ_0$: $κ$ bytes. The message authentication code computed over $β_0$ using the session key derived from $α_0$.
+
+- **$\tilde{k}$**: $κ$ bytes. The reply key, sampled uniformly at random by the initiating node.
 
 The total SURB size is:
 

--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -7,7 +7,7 @@
 | Status | raw |
 | Category | Standards Track |
 | Editor | Akshaya Mani <akshaya@status.im> |
-| Contributors | Prem Prathi <prem@status.im>, Daniel Kaiser <danielkaiser@status.im>, Hanno Cornelius |
+| Contributors | Prem Prathi <prem@status.im>, Daniel Kaiser <danielkaiser@status.im>, Hanno Cornelius <hanno@status.im> |
 
 <!-- timeline:start -->
 

--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -1281,8 +1281,8 @@ To construct each SURB, the initiating node MUST perform the following steps:
 
    $`
    \begin{array}{l}
-   β_{L-1} = \mathrm{AES\text{-}CTR}\bigl(β_{\mathrm{aes\_key}_{L-1}},\;
-   β_{\mathrm{iv}_{L-1}},\;
+   β_{L-1} = \mathrm{AES\text{-}CTR}\bigl(β_{\mathrm{aes\_key}_{L-1}},
+   β_{\mathrm{iv}_{L-1}},
    0_{tκ} \mid \mathrm{id} \mid 0_{(((t+1)(r-L))+1)κ}
    \bigr) \bigm| Φ_{L-1}
    \end{array}
@@ -1296,9 +1296,9 @@ To construct each SURB, the initiating node MUST perform the following steps:
 
 4. **Assemble SURB**
 
-   Assemble the SURB tuple $\mathrm{hop}_0,\; (α_0, β_0, γ_0),\; \tilde{k}$ as defined in [Section 8.7.1](#871-surb-component-sizes). Here $\mathrm{hop}_0$ is the address of the first hop on the return path. Embed the SURB in the message payload.
+   Assemble the SURB tuple $\mathrm{hop}_0, (α_0, β_0, γ_0), \tilde{k}$ as defined in [Section 8.7.1](#871-surb-component-sizes). Here $\mathrm{hop}_0$ is the address of the first hop on the return path. Embed the SURB in the message payload.
 
-   The initiating node MUST store the tuple $(\tilde{k},\; s_0,\; \ldots,\; s_{L-1})$ in a local table indexed by $\mathrm{id}$, for reply recovery defined in [Section 8.7.5](#875-reply-recovery).
+   The initiating node MUST store the tuple $(\tilde{k}, s_0, \ldots, s_{L-1})$ in a local table indexed by $\mathrm{id}$, for reply recovery defined in [Section 8.7.5](#875-reply-recovery).
 
 #### 8.7.3 Using a SURB
 
@@ -1306,7 +1306,7 @@ When the Exit Layer receives any SURBs as part of the handoff defined in [Sectio
 
 Note: Each retained SURB consists of the hop address of the first node in the return path, a pre-computed Sphinx header, and a reply key, as defined in [Section 8.7.1](#871-surb-component-sizes).
 
-Once the destination responds with a reply message, the Exit Layer MUST perform the following steps to use a SURB $(\mathrm{hop}_0,\; (α, β, γ),\; \tilde{k})$:
+Once the destination responds with a reply message, the Exit Layer MUST perform the following steps to use a SURB $(\mathrm{hop}_0, (α, β, γ), \tilde{k})$:
 
 1. **Prepare Reply Message**
 
@@ -1346,14 +1346,14 @@ When the Exit Layer receives decrypted payload $δ'$ and the SURB identifier $\m
 
 1. **Retrieve Decryption Keys**
 
-   Retrieve the decryption keys tuple $(\tilde{k},\; s_0,\; \ldots,\; s_{L-1})$ indexed by $\mathrm{id}$ stored as defined in [Section 8.7.2](#872-surb-creation) Step 4.
+   Retrieve the decryption keys tuple $(\tilde{k}, s_0, \ldots, s_{L-1})$ indexed by $\mathrm{id}$ stored as defined in [Section 8.7.2](#872-surb-creation) Step 4.
    
    If no tuple is found, discard the reply and terminate processing.
 
 2. **Recover Padded Reply Message**
 
    The encrypted payload $δ'$ contains the padded reply message $m$ defined in [Section 8.7.3](#873-using-a-surb) Step 1, prepended with a $κ$-byte string of zeros.
-   It is encrypted in $L + 1$ layers&mdash;first using the reply key $\tilde{k}$, then with each hop on the return path adding exactly one layer using the per-hop session key $s_0,\; \ldots,\; s_{L-1}$.
+   It is encrypted in $L + 1$ layers&mdash;first using the reply key $\tilde{k}$, then with each hop on the return path adding exactly one layer using the per-hop session key $s_0, \ldots, s_{L-1}$.
    To recover the padded reply message, perform the following steps for each layer $i = 0$ to $L$, recursively:
 
    - Derive per-hop AES key and IV:
@@ -1421,7 +1421,7 @@ When the Exit Layer receives decrypted payload $δ'$ and the SURB identifier $\m
 
    - Unpad $m$ using the deterministic padding scheme defined during construction in [Section 8.7.3](#873-using-a-surb) Step 1.
   
-   - Erase all temporary values and the stored decryption keys $(\tilde{k},\; s_0,\; \ldots,\; s_{L-1})$ from memory.
+   - Erase all temporary values and the stored decryption keys $(\tilde{k}, s_0, \ldots, s_{L-1})$ from memory.
 
 ## 9. Security Considerations
 

--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -978,6 +978,8 @@ After successful deserialization, the mix node performs the following steps:
    The table MAY be flushed when the node rotates its private key.
    Implementations SHOULD perform this cleanup securely and automatically.
 
+   Note: This check also enforces SURB single-use defined in [Section 8.7](#87-single-use-reply-blocks). A reused SURB produces a duplicate tag at the first return-path node and is discarded.
+
 3. **Check Header Integrity**
 
    - Derive the MAC key from the session secret $s$:
@@ -1225,7 +1227,7 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
 A Single-Use Reply Block (SURB) allows the recipient of a Sphinx packet to send a reply without learning the sender's identity, the return mix path, or any forwarding delays.
 
-A SURB MUST be used at most once. Reusing a SURB allows nodes on the return path to link multiple replies back to the original sender.
+The recipient MUST NOT use the same SURB more than once. Reusing a SURB would allow nodes on the return path to link multiple replies back to the original sender. The single-use requirement is enforced by the replay protection of [Section 8.6.1](#861-shared-preprocessing) Step 2.
 
 A SURB encodes a complete Sphinx header for a return path, a symmetric reply key, and a unique reply identifier. The initiating node constructs one or more SURBs and embeds them in the outgoing Sphinx packet payload. The recipient uses a SURB to reply — only the original sender can decrypt the reply.
 
@@ -1285,7 +1287,7 @@ To construct each SURB, the initiating node MUST perform the following steps:
    \begin{array}{l}
    β_{L-1} = \mathrm{AES\text{-}CTR}\bigl(β_{\mathrm{aes\_key}_{L-1}},
    β_{\mathrm{iv}_{L-1}},
-   0_{tκ} \mid \mathrm{id} \mid 0_{(((t+1)(r-L))+1)κ}
+   0_{tκ-2} \mid 0_2 \mid \mathrm{id} \mid 0_{(((t+1)(r-L))+1)κ}
    \bigr) \bigm| Φ_{L-1}
    \end{array}
    `$
@@ -1323,6 +1325,7 @@ Once the destination responds with a reply message, the Exit Layer MUST perform 
 3. **Assemble and Transmit Reply Packet**
 
    Assemble the Sphinx packet using the SURB header $(α, β, γ)$ and encrypted payload $δ$ from step 2, following the packet format defined in [Section 8.5.2](#852-construction-steps) Step 3.e. Serialize and transmit packet to $\mathrm{hop}_0$ (retrieved from the SURB) via a libp2p stream negotiated under the `"/mix/1.0.0"` protocol identifier.
+   Discard the SURB.
 
 #### 8.7.4 SURB Reply Processing
 

--- a/docs/ift-ts/raw/mix.md
+++ b/docs/ift-ts/raw/mix.md
@@ -877,7 +877,7 @@ The construction MUST proceed as follows:
      Note that the length of $\gamma_i$ is $κ$, $0 \leq i \leq L-1$ as defined in [Section 8.3.1](#831-header-field-sizes).
 
    d. **Encrypt Payload**
-   The encrypted payload $δ$ contains the message $m$ defined in Step 1, prepended with a $κ$-byte string of zeros.
+   The encrypted payload $δ$ contains the message $m$ defined in step 1, prepended with a $κ$-byte string of zeros.
    It is encrypted in layers such that each hop in the mix path removes exactly one layer using the per-hop session key.
    This ensures that only the final hop (_i.e.,_ the exit node) can fully recover $m$, validate its integrity, and forward it to the destination.
    To compute the encrypted payload, perform the following steps for each hop $i = L-1$ down to $0$, recursively:
@@ -916,7 +916,7 @@ The construction MUST proceed as follows:
 
      Note that the length of $\delta_i$, $0 \leq i \leq L-1$ is $|m| + κ$ bytes.
 
-     Given that the derived size of $\delta_i$ is $3984$ bytes as defined in [Section 8.3.2](#832-payload-size), this allows $m$ to be of length $3984-16 = 3968$ bytes as defined in Step 1.
+     Given that the derived size of $\delta_i$ is $3984$ bytes as defined in [Section 8.3.2](#832-payload-size), this allows $m$ to be of length $3984-16 = 3968$ bytes as defined in step 1.
 
    e. **Assemble Final Packet**
    The final Sphinx packet is structured as defined in [Section 8.3](#83-packet-component-sizes):
@@ -958,7 +958,7 @@ This section defines the exact behavior for both roles.
 
 Upon receiving a stream payload over a libp2p stream, the mix node MUST first deserialize it into a Sphinx packet `(α, β, γ, δ)`.
 
-The deserialized fields MUST match the sizes defined in [Section 8.5.2](#852-construction-steps) step 3.e., and the total packet length MUST match the fixed packet size defined in [Section 8.3.2](#832-payload-size).
+The deserialized fields MUST match the sizes defined in [Section 8.5.2](#852-construction-steps) Step 3.e., and the total packet length MUST match the fixed packet size defined in [Section 8.3.2](#832-payload-size).
 
 If the stream payload does not match the expected length, it MUST be discarded and the processing MUST terminate.
 
@@ -1023,7 +1023,7 @@ After successful deserialization, the mix node performs the following steps:
      \end{array}
      `$
 
-     This step removes the filler string appended during header encryption in [Section 8.5.2](#852-construction-steps) step 3.c. and yields the plaintext routing information for this hop.
+     This step removes the filler string appended during header encryption in [Section 8.5.2](#852-construction-steps) Step 3.c. and yields the plaintext routing information for this hop.
 
    The routing block $B$ MUST be parsed according to the rules and field layout defined in [Section 8.6.2](#862-node-role-determination) to determine whether the current node is an intermediary or the exit.
 
@@ -1055,7 +1055,7 @@ After successful deserialization, the mix node performs the following steps:
 
 As described in [Section 8.6.1](#861-shared-preprocessing), the mix node obtains the routing block $B$ by decrypting one layer of the encrypted header $β$.
 
-At this stage, the node MUST determine whether it is an intermediary or the exit based on the prefix of $B$, in accordance with the construction of $β_i$ defined in [Section 8.5.2](#852-construction-steps) step 3.c.:
+At this stage, the node MUST determine whether it is an intermediary or the exit based on the prefix of $B$, in accordance with the construction of $β_i$ defined in [Section 8.5.2](#852-construction-steps) Step 3.c.:
 
 - If $B_{[(tκ-2)\ldots tκ-1]}$ contains a two-byte zero delay, process the packet as an exit.
 - Otherwise, process the packet as an intermediary.
@@ -1068,7 +1068,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
 
 1. **Parse Routing Block**
 
-   Parse the routing block $B$ according to the $β_i$, $i \neq L - 1$ construction defined in [Section 8.5.2](#852-construction-steps) step 3.c.:
+   Parse the routing block $B$ according to the $β_i$, $i \neq L - 1$ construction defined in [Section 8.5.2](#852-construction-steps) Step 3.c.:
 
    - Extract the first $(tκ - 2)$ bytes of $B$ as the next hop address $\mathrm{addr}$
 
@@ -1117,7 +1117,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
      \end{aligned}
      `$
 
-   - Use the $β'$ and $γ'$ extracted in Step 1. as the routing information and MAC respectively in the outgoing packet.
+   - Use the $β'$ and $γ'$ extracted in step 1. as the routing information and MAC respectively in the outgoing packet.
 
 3. **Update Payload**
 
@@ -1138,7 +1138,7 @@ Once the node determines its role as an intermediary following the steps in [Sec
 
 5. **Transmit Packet**
 
-   - Interpret the $\mathrm{addr}$ and $\mathrm{delay}$ extracted in Step 1. according to the encoding format used during construction in [Section 8.5.2](#852-construction-steps) step 3.c.
+   - Interpret the $\mathrm{addr}$ and $\mathrm{delay}$ extracted in step 1. according to the encoding format used during construction in [Section 8.5.2](#852-construction-steps) Step 3.c.
 
    - Sample the actual forwarding delay from the configured delay distribution, using the decoded mean delay value as the distribution parameter.
 
@@ -1164,7 +1164,7 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
 1. **Parse Routing Block**
 
-   Parse the routing block $B$ according to the $β_i$, $i = L - 1$ construction defined in [Section 8.5.2](#852-construction-steps) step 3.c.:
+   Parse the routing block $B$ according to the $β_i$, $i = L - 1$ construction defined in [Section 8.5.2](#852-construction-steps) Step 3.c.:
 
    - Extract the first $(tκ - 2)$ bytes of $B$ as the destination address $Δ$
 
@@ -1216,7 +1216,7 @@ Once the node determines its role as an exit following the steps in [Section 8.6
 
 4. **Handoff to Exit Layer**
 
-   - Hand off the serialized application message, the origin protocol codec, destination address $Δ$ (extracted in Step 1.), and any SURBs extracted in Step 3. to the local Exit Layer for further processing and delivery.
+   - Hand off the serialized application message, the origin protocol codec, destination address $Δ$ (extracted in step 1.), and any SURBs extracted in step 3. to the local Exit Layer for further processing and delivery.
 
    - The Exit Layer is responsible for establishing a client-only connection and forwarding the message to the destination. Implementations MAY reuse an existing stream to the destination, if doing so does not introduce any observable linkability between forwarded messages.
      It is also responsible for storing any received SURBs and routing responses from the destination using them (see [Section 8.7.3](#873-using-a-surb)).
@@ -1262,7 +1262,7 @@ $`
 \end{aligned}
 `$
 
-Each SURB embedded in the message payload reduces the available application message space by $734$ bytes. With the allowable message size of $3968$ bytes derived in [Section 8.5.2](#852-construction-steps) step 3.d, attaching $n$ SURBs leaves $3968 - (n \times 734)$ bytes for the application message, protocol codec, and any exit abuse prevention proof.
+Each SURB embedded in the message payload reduces the available application message space by $734$ bytes. With the allowable message size of $3968$ bytes derived in [Section 8.5.2](#852-construction-steps) Step 3.d, attaching $n$ SURBs leaves $3968 - (n \times 734)$ bytes for the application message, protocol codec, and any exit abuse prevention proof.
 
 #### 8.7.2 SURB Creation
 
@@ -1271,7 +1271,7 @@ To construct each SURB, the initiating node MUST perform the following steps:
 
 1. **Select Return Path and Compute Ephemeral Secrets**
 
-   Select a return mix path of length $L \geq 3$ with the initiating node as the final hop. Compute the ephemeral public value $α_0$ and per-hop shared secrets $s_0, \ldots, s_{L-1}$ following the same procedure as [Section 8.5.2](#852-construction-steps) Step 2 and step 3.a.
+   Select a return mix path of length $L \geq 3$ with the initiating node as the final hop. Compute the ephemeral public value $α_0$ and per-hop shared secrets $s_0, \ldots, s_{L-1}$ following the same procedure as [Section 8.5.2](#852-construction-steps) Steps 2 and 3.a.
 
 2. **Sample SURB Identifier and Reply Key**
 
@@ -1279,7 +1279,7 @@ To construct each SURB, the initiating node MUST perform the following steps:
 
 3. **Construct Return Path Header**
 
-   Compute per-hop filler strings and construct the routing header following the same procedure in [Section 8.5.2](#852-construction-steps) steps 3.b and 3.c, with just $β_{L-1}$ computed as follows:
+   Compute per-hop filler strings and construct the routing header following the same procedure in [Section 8.5.2](#852-construction-steps) Steps 3.b and 3.c, with just $β_{L-1}$ computed as follows:
 
    $`
    \begin{array}{l}
@@ -1290,7 +1290,7 @@ To construct each SURB, the initiating node MUST perform the following steps:
    \end{array}
    `$
 
-   That is, encode zero address and delay followed by the SURB identifier $\mathrm{id}$ in $β_{L-1}$. The SURB identifier is embedded so that the initiating node can match an incoming reply to the stored decryption keys in Step 4 below.
+   That is, encode zero address and delay followed by the SURB identifier $\mathrm{id}$ in $β_{L-1}$. The SURB identifier is embedded so that the initiating node can match an incoming reply to the stored decryption keys in step 4 below.
 
    Use the same construction for the remaining routing blocks $β_i$, $0 \leq i < L-1$, and all per-hop MACs $γ_i$, $0 \leq i \leq L-1$.
 
@@ -1316,13 +1316,13 @@ Once the destination responds with a reply message, the Exit Layer MUST perform 
 
 2. **Encrypt Reply Payload**
 
-   Derive the AES key, IV, and compute the encrypted payload $δ$ following the same procedure in [Section 8.5.2](#852-construction-steps) step 3.d for $i = L-1$, substituting $\tilde{k}$ for $s_{L-1}$.
+   Derive the AES key, IV, and compute the encrypted payload $δ$ following the same procedure in [Section 8.5.2](#852-construction-steps) Step 3.d for $i = L-1$, substituting $\tilde{k}$ for $s_{L-1}$.
 
-   Note: Unlike the forward path ([Section 8.5.2](#852-construction-steps) step 3.d), the reply payload is encrypted only once&mdash;using $\tilde{k}$ alone. Each mix node on the return path will apply one additional layer during Sphinx processing ([Section 8.6.1](#861-shared-preprocessing) Step 5), resulting in $L + 1$ layers total that the initiating node must remove during reply recovery (see [Section 8.7.5](#875-reply-recovery)).
+   Note: Unlike the forward path ([Section 8.5.2](#852-construction-steps) Step 3.d), the reply payload is encrypted only once&mdash;using $\tilde{k}$ alone. Each mix node on the return path will apply one additional layer during Sphinx processing ([Section 8.6.1](#861-shared-preprocessing) Step 5), resulting in $L + 1$ layers total that the initiating node must remove during reply recovery (see [Section 8.7.5](#875-reply-recovery)).
 
 3. **Assemble and Transmit Reply Packet**
 
-   Assemble the Sphinx packet using the SURB header $(α, β, γ)$ and encrypted payload $δ$ from Step 2, following the packet format defined in [Section 8.5.2](#852-construction-steps) step 3.e. Serialize and transmit packet to $\mathrm{hop}_0$ (retrieved from the SURB) via a libp2p stream negotiated under the `"/mix/1.0.0"` protocol identifier.
+   Assemble the Sphinx packet using the SURB header $(α, β, γ)$ and encrypted payload $δ$ from step 2, following the packet format defined in [Section 8.5.2](#852-construction-steps) Step 3.e. Serialize and transmit packet to $\mathrm{hop}_0$ (retrieved from the SURB) via a libp2p stream negotiated under the `"/mix/1.0.0"` protocol identifier.
 
 #### 8.7.4 SURB Reply Processing
 


### PR DESCRIPTION
This PR adds §8.7 Single-Use Reply Blocks (SURBs) to `mix.md`, specifying how SURBs are structured, created, used by recipients, processed by mix nodes, and recovered by the Exit Layer. Targets `chore/mix-restructure`.

#### Key changes

- **§8.7.1 SURB Component Sizes:** Defines the structure and byte sizes of SURBs 
- **§8.7.2 SURB Creation:** Specifies how the initiating node constructs a SURB and embeds it in the message, stores the reply key tuple for later recovery
- **§8.7.3 Using a SURB:** Specifies how the recipient wraps its reply in a Sphinx packet using the received SURB
- **§8.7.4 SURB Reply Processing:** Specifies how a mix node detects and processes an incoming SURB-based reply packet during Sphinx processing
- **§8.7.5 Reply Recovery:** Specifies how the initiating node recovers the plaintext reply by decrypting $L+1$ `AES-CTR` layers

#### Fixes and Cleanup

- Fix broken section cross-references
- Formatting fixes and typos

[!NOTE] §8.7.5 currently uses `AES-CTR` for reply decryption, consistent with the rest of the spec. The broader integrity limitation is tracked in #306 .