### PR TITLE
chore: metadata validator improvements

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -28,6 +28,11 @@ jobs:
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
 
+          python3 scripts/validate_metadata.py --check
+          python3 scripts/gen_rfc_index.py
+          python3 scripts/gen_summary.py
+          python3 scripts/validate_generated_outputs.py
+  
           python3 scripts/lint_targets.py --base-sha "$BASE" --head-sha "$HEAD" --output .lint-targets.txt
 
           if [ ! -s .lint-targets.txt ]; then
@@ -37,7 +42,6 @@ jobs:
 
           mapfile -t files < .lint-targets.txt
 
-          python3 scripts/validate_metadata.py --check
           npx markdownlint-cli2@0.12.1 --config .markdownlint.yaml "${files[@]}"
 
   remark:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ build:
 	mdbook build
 
 lint:
+	python scripts/gen_rfc_index.py
+	python scripts/gen_summary.py
 	python scripts/validate_metadata.py --check
+	python scripts/validate_generated_outputs.py
 	npx markdownlint-cli2@0.12.1 "docs/**/*.md" --config .markdownlint.yaml
 	npm run lint:remark

--- a/docs/storage/raw/merkle-tree.md
+++ b/docs/storage/raw/merkle-tree.md
@@ -412,7 +412,7 @@ These all come with some advantages and disadvantages, and are useful in differe
 
 A hash is 256 bits (32 bytes). The keys `0,1,2,3` are encoded as a single byte, `0x00, ..., 0x03`. The keyed compression function is defined as 
 
-```
+```text
     compress(x,y,key) := SHA256( x || y || key )
 ```
 
@@ -438,7 +438,7 @@ We can avoid this by encoding the key into the initialization vector (from a bir
 
 Standard SHA256 derives its initial state (which is 256 bits) from the square roots of the first 8 primes. This is known as a "nothing-up-to-my-sleeve" construction. But really it could be just about anything. Here we need 4 different random-looking initial states corresponding to the 4 different keys. We propose
 
-```
+```text
 IV_0 := SHA3-256("LOGOS_STORAGE|MERKLE_SHA256_INITIAL_STATE|KEY=0x00")
 IV_1 := SHA3-256("LOGOS_STORAGE|MERKLE_SHA256_INITIAL_STATE|KEY=0x01")
 IV_2 := SHA3-256("LOGOS_STORAGE|MERKLE_SHA256_INITIAL_STATE|KEY=0x02")
@@ -449,7 +449,7 @@ IV_3 := SHA3-256("LOGOS_STORAGE|MERKLE_SHA256_INITIAL_STATE|KEY=0x03")
 
 In concrete (big-endian) values, these are:
 
-```
+```text
 IV_0 = 0xc616dedc2fd8bba1e2c31efeb8555bfa37efe48c7e84c7d67cc9afa0b008b2b7
 IV_1 = 0x08e555becbc79204178a3e20f689eb74552523e5d75d42e8be555a9ee671bd86
 IV_2 = 0x53eabf5ee9bff4c87515e738558093128797f2015d5994443787a215875a9a27
@@ -458,13 +458,13 @@ IV_3 = 0x17c13498c9884a64005dda79b147b9a9c88588c62fb7138fb72d528c01eb8287
 
 However, SHA256 initial state is represented as a length 8 array of 32-bit words. As customary, the encoding for these words is big-endian, so for example `IV_0` will become
 
-```
+```text
     IV_0 = { 0xc616dedc, 0x2fd8bba1, 0xe2c31efe, 0xb8555bfa, 0x37efe48c, 0x7e84c7d6, 0x7cc9afa0, 0xb008b2b7 }
 ```
 
 Our keyed compression function then would be:
 
-```
+```text
     compress(x,y,key) := SHA256_COMPRESS( init = IV_key, chunk = x||y )
 ```
 
@@ -482,7 +482,7 @@ Poseidon2 hash function is parametrized by a prime field, and the other paramete
 
 In this case, the field is the BN254 (aka. alt-bn128 or sometimes BN256 - though the latter name is also used for a different curve!) elliptic curve's scalar field:
 
-```
+```text
     p = 21888242871839275222246405745257275088548364400416034343698204186575808495617
 ```
 
@@ -492,13 +492,13 @@ We use the parameters from the `zkfriendlyhashzoo` [implementation](https://extg
 
 This defines the so called "Poseidon2 permutation function":
 
-```
+```text
     permute : F^3 -> F^3
 ```
     
 From this, our keyed compression function is derived as:
 
-```
+```text
     compress(x,y,key) := permute([x,y,key])[0]
 ```
     
@@ -514,7 +514,7 @@ Linear hashing of bytes. First we need to pad the byte sequence to a multiple of
 
 Permutation of `(0,1,2)`:
 
-```
+```text
 x' = 0x30610a447b7dec194697fb50786aa7421494bd64c221ba4d3b1af25fb07bd103 
 y' = 0x13f731d6ffbad391be22d2ac364151849e19fa38eced4e761bcd21dbdc600288 
 z' = 0x1433e2c8f68382c447c5c14b8b3df7cbfd9273dd655fe52f1357c27150da786f 
@@ -522,7 +522,7 @@ z' = 0x1433e2c8f68382c447c5c14b8b3df7cbfd9273dd655fe52f1357c27150da786f
 
 Keyed compression:
 
-```
+```text
 compress(x=1234, y=5678, key=0) = 0x152ef46ec26a9afb6748e7fff3f75081af33f84b77d2afa05207509fb63ec4a6
 compress(x=6666, y=7777, key=1) = 0x04f222443879d40e17174f08adfd76c23d515d370e351f5d5da69a41d84dc48a
 compress(x=9876, y=5432, key=2) = 0x1ddd85a82b30a09cded68735a8fb9a353e6448f64f28f96a6f0e495b4e50f372
@@ -540,7 +540,7 @@ compress(x=1133, y=5577, key=3) = 0x222eda4baf17bf55f2167e6c9cd8828b8cb1762cfc61
 
 The Goldilocks prime field is defined by
 
-```
+```text
     p  =  2^64 - 2^32 + 1  =  18446744069414584321
 ```
     
@@ -550,7 +550,7 @@ The parameters we use are the same as the [HorizenLabs implementation](https://g
 
 The keyed compression function is then defined as:
 
-```
+```text
 compress( [x0,x1,x2,x3], [y0,y1,y2,y3], key) := 
   let newState = permute( [x0,x1,x2,x3, y0,y1,y2,y3, key,0,0,0] ) 
   in  newState[0..3]
@@ -598,7 +598,7 @@ void goldilocks_convert_31_bytes_to_4_field_elements(const uint8_t *ptr, uint64_
 
 Again care should we taken with the padding and domain separation! By convention, the domain separation value is put in the 8th field element of the initial state:
 
-```
+```text
     initial_state = [0,0,0,0, 0,0,0,0, domSep,0,0,0]
 ```
 
@@ -606,7 +606,7 @@ Again care should we taken with the padding and domain separation! By convention
 
 Permutation of `[0,1,2,..9,10,11]`:
 
-```
+```text
     [ 0x01eaef96bdf1c0c1
     , 0x1f0d2cc525b2540c
     , 0x6282c1dfe1e0358d
@@ -638,7 +638,7 @@ We use the parameters from the `zkfriendlyhashzoo` [implementation](https://extg
 
 Permutation of `[0,1,2,..9,10,11]`:
 
-```
+```text
     [ 0x516dd661e959f541
     , 0x082c137169707901
     , 0x53dff3fd9f0a5beb
@@ -657,4 +657,3 @@ Permutation of `[0,1,2,..9,10,11]`:
 #### Implementation
 
 - [https://github.com/logos-storage/nim-goldilocks-hash](https://github.com/logos-storage/nim-goldilocks-hash) (includes the Merkle tree construction)
-

--- a/scripts/gen_rfc_index.py
+++ b/scripts/gen_rfc_index.py
@@ -19,7 +19,7 @@ ROOT = Path(__file__).resolve().parent.parent
 DOCS = ROOT / "docs"
 OUTPUT = DOCS / "logos-lips.json"
 
-EXCLUDE_FILES = {"README.md", "SUMMARY.md", "about.md"}
+EXCLUDE_FILES = {"README.md", "SUMMARY.md", "about.md", "template.md"}
 EXCLUDE_PARTS = {"previous-versions"}
 
 

--- a/scripts/gen_summary.py
+++ b/scripts/gen_summary.py
@@ -15,7 +15,7 @@ ROOT = Path(__file__).resolve().parent.parent
 DOCS = ROOT / "docs"
 OUTPUT = DOCS / "SUMMARY.md"
 
-SKIP_FILES = {"README.md", "SUMMARY.md"}
+SKIP_FILES = {"README.md", "SUMMARY.md", "template.md"}
 
 TOP_LEVEL = ["messaging", "blockchain", "storage", "ift-ts"]
 

--- a/scripts/run_runtime_generators.py
+++ b/scripts/run_runtime_generators.py
@@ -14,13 +14,16 @@ SCRIPTS = [
     "scripts/gen_history.py",
     "scripts/gen_rfc_index.py",
     "scripts/gen_summary.py",
+    "scripts/validate_generated_outputs.py",
 ]
 
 
 def run(script: str) -> None:
-    path = ROOT / script
-    print(f"[INFO] Running {path}")
-    result = subprocess.run([sys.executable, str(path)], cwd=ROOT)
+    parts = script.split()
+    path = ROOT / parts[0]
+    args = parts[1:]
+    print(f"[INFO] Running {path} {' '.join(args)}".rstrip())
+    result = subprocess.run([sys.executable, str(path), *args], cwd=ROOT)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
 

--- a/scripts/validate_generated_outputs.py
+++ b/scripts/validate_generated_outputs.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Validate generated mdBook and landing-page indexes against source specs.
+
+Run this after `gen_rfc_index.py` and `gen_summary.py`.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+from validate_metadata import DOCS, ROOT, discover_docs, read_doc
+
+SUMMARY = DOCS / "SUMMARY.md"
+INDEX = DOCS / "logos-lips.json"
+EXCLUDE_INDEX_PARTS = {"previous-versions"}
+SUMMARY_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+\.md(?:#[^)]+)?)\)")
+
+
+def parse_summary_links() -> Tuple[set[Path], List[str]]:
+    links: set[Path] = set()
+    errors: List[str] = []
+
+    if not SUMMARY.exists():
+        return links, [f"{SUMMARY.relative_to(ROOT)} is missing"]
+
+    text = SUMMARY.read_text(encoding="utf-8", errors="ignore")
+    for match in SUMMARY_LINK_RE.finditer(text):
+        raw_target = match.group(1).split("#", 1)[0].strip()
+        if re.match(r"^[a-z][a-z0-9+.-]*:", raw_target, re.IGNORECASE):
+            continue
+        target = (DOCS / raw_target).resolve()
+        if not target.is_relative_to(DOCS.resolve()):
+            errors.append(f"{SUMMARY.relative_to(ROOT)} links outside docs/: {raw_target}")
+            continue
+        if not target.exists():
+            errors.append(f"{SUMMARY.relative_to(ROOT)} links to missing file: {raw_target}")
+            continue
+        links.add(target)
+
+    return links, errors
+
+
+def validate_summary_coverage() -> List[str]:
+    linked_paths, errors = parse_summary_links()
+    expected_paths = {path.resolve() for path in discover_docs()}
+
+    missing = sorted(expected_paths - linked_paths)
+    if missing:
+        joined = ", ".join(str(path.relative_to(ROOT)) for path in missing)
+        errors.append(f"{SUMMARY.relative_to(ROOT)} is missing spec link(s): {joined}")
+
+    extra = sorted(
+        path
+        for path in linked_paths - expected_paths
+        if path.name not in {"README.md", "about.md"}
+    )
+    if extra:
+        joined = ", ".join(str(path.relative_to(ROOT)) for path in extra)
+        errors.append(f"{SUMMARY.relative_to(ROOT)} links non-spec Markdown file(s): {joined}")
+
+    return errors
+
+
+def validate_index_coverage() -> List[str]:
+    if not INDEX.exists():
+        return [f"{INDEX.relative_to(ROOT)} is missing"]
+
+    try:
+        data = json.loads(INDEX.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"{INDEX.relative_to(ROOT)} is invalid JSON: {exc}"]
+
+    if not isinstance(data, list):
+        return [f"{INDEX.relative_to(ROOT)} must contain a JSON list"]
+
+    actual_paths = {
+        item.get("path")
+        for item in data
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    }
+    expected_paths = {
+        read_doc(path).rel.relative_to("docs").with_suffix(".html").as_posix()
+        for path in discover_docs()
+        if not EXCLUDE_INDEX_PARTS.intersection(path.relative_to(ROOT).parts)
+    }
+
+    errors: List[str] = []
+    missing = sorted(expected_paths - actual_paths)
+    if missing:
+        errors.append(
+            f"{INDEX.relative_to(ROOT)} is missing spec path(s): {', '.join(missing)}"
+        )
+
+    extra = sorted(actual_paths - expected_paths)
+    if extra:
+        errors.append(
+            f"{INDEX.relative_to(ROOT)} contains non-spec path(s): {', '.join(extra)}"
+        )
+
+    return errors
+
+
+def main() -> int:
+    errors = validate_summary_coverage()
+    errors.extend(validate_index_coverage())
+
+    for error in errors:
+        print(f"[ERROR] {error}")
+
+    if errors:
+        print(f"[FAIL] generated output validation failed with {len(errors)} error(s)")
+        return 1
+
+    print("[OK] generated output validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -36,6 +36,11 @@ SEPARATOR_RE = re.compile(r"^\|\s*:?-{3,}:?\s*\|\s*:?-{3,}:?\s*\|$")
 ROW_RE = re.compile(r"^\|\s*([^|]+?)\s*\|\s*(.*?)\s*\|$")
 HEADER_RE = re.compile(r"^\|\s*field\s*\|\s*value\s*\|$", re.IGNORECASE)
 NUMERIC_RE = re.compile(r"^[1-9][0-9]*$")
+FRONT_MATTER_KEY_RE = re.compile(
+    r"^(title|name|slug|status|type|category|tags|editor|contributors)\s*:",
+    re.IGNORECASE,
+)
+CANONICAL_HEADER = "| Field | Value |"
 
 
 @dataclass
@@ -103,6 +108,35 @@ def find_metadata_table(lines: List[str]) -> Optional[TableInfo]:
 
         return TableInfo(start=idx, separator=idx + 1, end=row_idx, rows=rows)
     return None
+
+
+def first_nonblank_line(lines: List[str], start: int = 0) -> Optional[int]:
+    for idx in range(start, len(lines)):
+        if lines[idx].strip():
+            return idx
+    return None
+
+
+def has_yaml_front_matter(lines: List[str]) -> bool:
+    first = first_nonblank_line(lines)
+    if first is None or lines[first].strip() != "---":
+        return False
+
+    for idx in range(first + 1, min(len(lines), first + 80)):
+        line = lines[idx].strip()
+        if line == "---":
+            block = lines[first + 1 : idx]
+            return any(FRONT_MATTER_KEY_RE.match(item.strip()) for item in block)
+    return False
+
+
+def expected_metadata_table_start(lines: List[str]) -> Optional[int]:
+    first = first_nonblank_line(lines)
+    if first is None:
+        return None
+    if lines[first].startswith("# "):
+        return first_nonblank_line(lines, first + 1)
+    return first
 
 
 def read_doc(path: Path) -> DocInfo:
@@ -180,13 +214,24 @@ def maybe_assign_slugs(docs: List[DocInfo], check_mode: bool) -> List[DocInfo]:
 
 
 def validate_doc(doc: DocInfo) -> None:
+    if has_yaml_front_matter(doc.lines):
+        doc.errors.append(
+            "YAML front matter is not supported; use the canonical Markdown metadata table"
+        )
+
     if not doc.table:
-        doc.errors.append("missing metadata table '| Field | Value |'")
+        doc.errors.append(f"missing metadata table '{CANONICAL_HEADER}'")
         return
 
+    expected_start = expected_metadata_table_start(doc.lines)
+    if expected_start is not None and doc.table.start != expected_start:
+        doc.errors.append(
+            "metadata table must appear at the top of the spec, immediately after the optional H1"
+        )
+
     # Ensure standard header rows remain canonical.
-    if doc.lines[doc.table.start].strip() != "| Field | Value |":
-        doc.errors.append("metadata header row must be exactly '| Field | Value |'")
+    if doc.lines[doc.table.start].strip() != CANONICAL_HEADER:
+        doc.errors.append(f"metadata header row must be exactly '{CANONICAL_HEADER}'")
     if not SEPARATOR_RE.match(doc.lines[doc.table.separator].strip()):
         doc.errors.append("metadata separator row is malformed")
 


### PR DESCRIPTION
## Summary

- Require specs to use the canonical Markdown metadata table and reject YAML front matter.
- Add generated-output validation to ensure specs are present in both `docs/SUMMARY.md` and `docs/logos-lips.json`.
- Exclude `template.md` from generated summary/index outputs.
- Run generated-output validation after summary/index generation in build/lint flows.
- Add missing fenced-code languages in `docs/storage/raw/merkle-tree.md` so markdownlint passes.

## Testing

- `python scripts/validate_metadata.py --check`
- `python scripts/gen_rfc_index.py && python scripts/gen_summary.py && python scripts/validate_generated_outputs.py`
- `make lint`
