### PR TITLE
chore(blockchain): migrate contributor emails to @logos.co

### DIFF
--- a/docs/blockchain/deprecated/claro.md
+++ b/docs/blockchain/deprecated/claro.md
@@ -7,7 +7,7 @@
 | Status | deprecated |
 | Type | RFC |
 | Category | Standards Track |
-| Editor | Corey Petty <corey@status.im> |
+| Editor | Corey Petty <corey@logos.co> |
 | Contributors | Álvaro Castro-Castilla, Mark Evenson |
 
 <!-- timeline:start -->

--- a/docs/blockchain/draft/p2p-network.md
+++ b/docs/blockchain/draft/p2p-network.md
@@ -7,8 +7,8 @@
 | Status | draft |
 | Type | RFC |
 | Category | networking |
-| Editor | Daniel Sanchez-Quiros <danielsq@status.im> |
-| Contributors | Filip Dimitrijevic <filip@status.im> |
+| Editor | Daniel Sanchez-Quiros <danielsq@logos.co> |
+| Contributors | Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/bedrock-anonymous-leaders-reward.md
+++ b/docs/blockchain/raw/bedrock-anonymous-leaders-reward.md
@@ -6,8 +6,8 @@
 | Slug | 85 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Thomas Lavaur <thomaslavaur@status.im> |
-| Contributors | David Rusu <davidrusu@status.im>, Mehmet Gonen <mehmet@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Frederico Teixeira <frederico@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Thomas Lavaur <thomaslavaur@logos.co> |
+| Contributors | David Rusu <davidrusu@logos.co>, Mehmet Gonen <mehmet@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Frederico Teixeira <frederico@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/bedrock-architecture-overview.md
+++ b/docs/blockchain/raw/bedrock-architecture-overview.md
@@ -6,8 +6,8 @@
 | Slug | 146 |
 | Status | raw |
 | Category | Informational |
-| Editor | David Rusu <davidrusu@status.im> |
-| Contributors | Álvaro Castro-Castilla <alvaro@status.im>, Daniel Kashepava <danielkashepava@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | David Rusu <davidrusu@logos.co> |
+| Contributors | Álvaro Castro-Castilla <alvaro@logos.co>, Daniel Kashepava <danielkashepava@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/bedrock-genesis-block.md
+++ b/docs/blockchain/raw/bedrock-genesis-block.md
@@ -6,8 +6,8 @@
 | Slug | 90 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | David Rusu <davidrusu@status.im> |
-| Contributors | Hong-Sheng Zhou, Thomas Lavaur <thomaslavaur@status.im>, Marcin Pawlowski <marcin@status.im>, Mehmet Gonen <mehmet@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Daniel Sanchez Quiros <danielsq@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | David Rusu <davidrusu@logos.co> |
+| Contributors | Hong-Sheng Zhou, Thomas Lavaur <thomaslavaur@logos.co>, Marcin Pawlowski <marcin@logos.co>, Mehmet Gonen <mehmet@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Daniel Sanchez Quiros <danielsq@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/bedrock-service-declaration-protocol.md
+++ b/docs/blockchain/raw/bedrock-service-declaration-protocol.md
@@ -6,8 +6,8 @@
 | Slug | 87 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Marcin Pawlowski <marcin@status.im> |
-| Contributors | Mehmet Gonen <mehmet@status.im>, Daniel Sanchez Quiros <danielsq@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Thomas Lavaur <thomaslavaur@status.im>, Gusto Bacvinka <augustinas@status.im>, David Rusu <davidrusu@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Marcin Pawlowski <marcin@logos.co> |
+| Contributors | Mehmet Gonen <mehmet@logos.co>, Daniel Sanchez Quiros <danielsq@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Thomas Lavaur <thomaslavaur@logos.co>, Gusto Bacvinka <augustinas@logos.co>, David Rusu <davidrusu@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/bedrock-service-reward-distribution.md
+++ b/docs/blockchain/raw/bedrock-service-reward-distribution.md
@@ -6,8 +6,8 @@
 | Slug | 86 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Thomas Lavaur <thomaslavaur@status.im> |
-| Contributors | David Rusu <davidrusu@status.im>, Mehmet Gonen <mehmet@status.im>, Marcin Pawlowski <marcin@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Thomas Lavaur <thomaslavaur@logos.co> |
+| Contributors | David Rusu <davidrusu@logos.co>, Mehmet Gonen <mehmet@logos.co>, Marcin Pawlowski <marcin@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/bedrock-v1.1-block-construction.md
+++ b/docs/blockchain/raw/bedrock-v1.1-block-construction.md
@@ -6,8 +6,8 @@
 | Slug | 93 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Marcin Pawlowski <marcin@status.im> |
-| Contributors | Thomas Lavaur <thomaslavaur@status.im>, Daniel Sanchez Quiros <danielsq@status.im>, David Rusu <davidrusu@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Mehmet Gonen <mehmet@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Marcin Pawlowski <marcin@logos.co> |
+| Contributors | Thomas Lavaur <thomaslavaur@logos.co>, Daniel Sanchez Quiros <danielsq@logos.co>, David Rusu <davidrusu@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Mehmet Gonen <mehmet@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/bedrock-v1.1-mantle-specification.md
+++ b/docs/blockchain/raw/bedrock-v1.1-mantle-specification.md
@@ -6,8 +6,8 @@
 | Slug | 98 |
 | Status | raw |
 | Category | Informational |
-| Editor | Thomas Lavaur <thomaslavaur@status.im> |
-| Contributors | David Rusu <davidrusu@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Thomas Lavaur <thomaslavaur@logos.co> |
+| Contributors | David Rusu <davidrusu@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/cryptarchia-proof-of-leadership.md
+++ b/docs/blockchain/raw/cryptarchia-proof-of-leadership.md
@@ -6,8 +6,8 @@
 | Slug | 83 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Thomas Lavaur <thomas@status.im> |
-| Contributors | Mehmet <mehmet@status.im>, Giacomo Pasini <giacomo@status.im>, Daniel Sanchez Quiros <daniel@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, David Rusu <david@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Thomas Lavaur <thomas@logos.co> |
+| Contributors | Mehmet <mehmet@logos.co>, Giacomo Pasini <giacomo@logos.co>, Daniel Sanchez Quiros <daniel@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, David Rusu <david@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/cryptarchia-total-stake-inference.md
+++ b/docs/blockchain/raw/cryptarchia-total-stake-inference.md
@@ -6,8 +6,8 @@
 | Slug | 94 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | David Rusu <davidrusu@status.im> |
-| Contributors | Alexander Mozeika <alexander.mozeika@status.im>, Daniel Kashepava <danielkashepava@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | David Rusu <davidrusu@logos.co> |
+| Contributors | Alexander Mozeika <alexander.mozeika@logos.co>, Daniel Kashepava <danielkashepava@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/cryptarchia-v1-bootstr-sync.md
+++ b/docs/blockchain/raw/cryptarchia-v1-bootstr-sync.md
@@ -6,8 +6,8 @@
 | Slug | 96 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Youngjoon Lee <youngjoon@status.im> |
-| Contributors | David Rusu <david@status.im>, Giacomo Pasini <giacomo@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Daniel Sanchez Quiros <daniel@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Youngjoon Lee <youngjoon@logos.co> |
+| Contributors | David Rusu <david@logos.co>, Giacomo Pasini <giacomo@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Daniel Sanchez Quiros <daniel@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/da-cryptographic-protocol.md
+++ b/docs/blockchain/raw/da-cryptographic-protocol.md
@@ -6,8 +6,8 @@
 | Slug | 148 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Mehmet Gonen <mehmet@status.im> |
-| Contributors | Álvaro Castro-Castilla <alvaro@status.im>, Thomas Lavaur <thomaslavaur@status.im>, Daniel Kashepava <danielkashepava@status.im>, Marcin Pawlowski <marcin@status.im>, Daniel Sanchez Quiros <danielsq@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Mehmet Gonen <mehmet@logos.co> |
+| Contributors | Álvaro Castro-Castilla <alvaro@logos.co>, Thomas Lavaur <thomaslavaur@logos.co>, Daniel Kashepava <danielkashepava@logos.co>, Marcin Pawlowski <marcin@logos.co>, Daniel Sanchez Quiros <danielsq@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/da-rewarding.md
+++ b/docs/blockchain/raw/da-rewarding.md
@@ -6,8 +6,8 @@
 | Slug | 149 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Marcin Pawlowski <marcin@status.im> |
-| Contributors | Alexander Mozeika <alexander.mozeika@status.im>, Mehmet Gonen <mehmet@status.im>, Daniel Sanchez Quiros <danielsq@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Marcin Pawlowski <marcin@logos.co> |
+| Contributors | Alexander Mozeika <alexander.mozeika@logos.co>, Mehmet Gonen <mehmet@logos.co>, Daniel Sanchez Quiros <danielsq@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/digital-signature.md
+++ b/docs/blockchain/raw/digital-signature.md
@@ -6,8 +6,8 @@
 | Slug | 150 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Jimmy Debe <jimmy@status.im> |
-| Contributors | Filip Dimitrijevic <filip@status.im> |
+| Editor | Jimmy Debe <jimmy@logos.co> |
+| Contributors | Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/fork-choice.md
+++ b/docs/blockchain/raw/fork-choice.md
@@ -6,8 +6,8 @@
 | Slug | 147 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | David Rusu <davidrusu@status.im> |
-| Contributors | Jimmy Debe <jimmy@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | David Rusu <davidrusu@logos.co> |
+| Contributors | Jimmy Debe <jimmy@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomos-blend-protocol.md
+++ b/docs/blockchain/raw/nomos-blend-protocol.md
@@ -7,7 +7,7 @@
 | Status | raw |
 | Category | Standards Track |
 | Editor | Marcin Pawlowski |
-| Contributors | Alexander Mozeika <alexander.mozeika@status.im>, Youngjoon Lee <youngjoon@status.im>, Frederico Teixeira <frederico@status.im>, Mehmet Gonen <mehmet@status.im>, Daniel Sanchez Quiros <danielsq@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Daniel Kashepava <danielkashepava@status.im>, Thomas Lavaur <thomaslavaur@status.im>, Antonio Antonino <antonio@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Contributors | Alexander Mozeika <alexander.mozeika@logos.co>, Youngjoon Lee <youngjoon@logos.co>, Frederico Teixeira <frederico@logos.co>, Mehmet Gonen <mehmet@logos.co>, Daniel Sanchez Quiros <danielsq@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Daniel Kashepava <danielkashepava@logos.co>, Thomas Lavaur <thomaslavaur@logos.co>, Antonio Antonino <antonio@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomos-cryptarchia-v1-protocol.md
+++ b/docs/blockchain/raw/nomos-cryptarchia-v1-protocol.md
@@ -6,8 +6,8 @@
 | Slug | 92 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | David Rusu <david@status.im> |
-| Contributors | Álvaro Castro-Castilla <alvaro@status.im>, Giacomo Pasini <giacomo@status.im>, Thomas Lavaur <thomas@status.im>, Mehmet <mehmet@status.im>, Marcin Pawlowski <marcin@status.im>, Daniel Sanchez Quiros <daniel@status.im>, Youngjoon Lee <youngjoon@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | David Rusu <david@logos.co> |
+| Contributors | Álvaro Castro-Castilla <alvaro@logos.co>, Giacomo Pasini <giacomo@logos.co>, Thomas Lavaur <thomas@logos.co>, Mehmet <mehmet@logos.co>, Marcin Pawlowski <marcin@logos.co>, Daniel Sanchez Quiros <daniel@logos.co>, Youngjoon Lee <youngjoon@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomos-key-types-and-generation.md
+++ b/docs/blockchain/raw/nomos-key-types-and-generation.md
@@ -6,8 +6,8 @@
 | Slug | 84 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Mehmet Gonen <mehmet@status.im> |
-| Contributors | Marcin Pawlowski <marcin@status.im>, Youngjoon Lee <youngjoon@status.im>, Alexander Mozeika <alexander@status.im>, Thomas Lavaur <thomaslavaur@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Mehmet Gonen <mehmet@logos.co> |
+| Contributors | Marcin Pawlowski <marcin@logos.co>, Youngjoon Lee <youngjoon@logos.co>, Alexander Mozeika <alexander@logos.co>, Thomas Lavaur <thomaslavaur@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomos-message-encapsulation.md
+++ b/docs/blockchain/raw/nomos-message-encapsulation.md
@@ -7,7 +7,7 @@
 | Status | raw |
 | Category | Standards Track |
 | Editor | Marcin Pawlowski |
-| Contributors | Youngjoon Lee <youngjoon@status.im>, Alexander Mozeika <alexander.mozeika@status.im>, Mehmet Gonen <mehmet@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Daniel Kashepava <danielkashepava@status.im>, Daniel Sanchez Quiros <danielsq@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Contributors | Youngjoon Lee <youngjoon@logos.co>, Alexander Mozeika <alexander.mozeika@logos.co>, Mehmet Gonen <mehmet@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Daniel Kashepava <danielkashepava@logos.co>, Daniel Sanchez Quiros <danielsq@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomos-message-formatting.md
+++ b/docs/blockchain/raw/nomos-message-formatting.md
@@ -7,7 +7,7 @@
 | Status | raw |
 | Category | Standards Track |
 | Editor | Marcin Pawlowski |
-| Contributors | Youngjoon Lee <youngjoon@status.im>, Alexander Mozeika <alexander.mozeika@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Contributors | Youngjoon Lee <youngjoon@logos.co>, Alexander Mozeika <alexander.mozeika@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomos-payload-formatting.md
+++ b/docs/blockchain/raw/nomos-payload-formatting.md
@@ -6,8 +6,8 @@
 | Slug | 97 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Marcin Pawlowski <marcin@status.im> |
-| Contributors | Youngjoon Lee <youngjoon@status.im>, Alexander Mozeika <alexander.mozeika@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Marcin Pawlowski <marcin@logos.co> |
+| Contributors | Youngjoon Lee <youngjoon@logos.co>, Alexander Mozeika <alexander.mozeika@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomos-proof-of-quota.md
+++ b/docs/blockchain/raw/nomos-proof-of-quota.md
@@ -6,8 +6,8 @@
 | Slug | 88 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Mehmet Gonen <mehmet@status.im> |
-| Contributors | Marcin Pawlowski <marcin@status.im>, Thomas Lavaur <thomaslavaur@status.im>, Youngjoon Lee <youngjoon@status.im>, David Rusu <davidrusu@status.im>, Álvaro Castro-Castilla <alvaro@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Mehmet Gonen <mehmet@logos.co> |
+| Contributors | Marcin Pawlowski <marcin@logos.co>, Thomas Lavaur <thomaslavaur@logos.co>, Youngjoon Lee <youngjoon@logos.co>, David Rusu <davidrusu@logos.co>, Álvaro Castro-Castilla <alvaro@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomos-wallet-technical-standard.md
+++ b/docs/blockchain/raw/nomos-wallet-technical-standard.md
@@ -7,8 +7,8 @@
 | Status | raw |
 | Category | Standards Track |
 | Tags | wallet, key derivation, HD wallet, mnemonic, BIP-32, BIP-39, Poseidon2 |
-| Editor | Giacomo Pasini <giacomo@status.im> |
-| Contributors | Thomas Lavaur <thomas@status.im>, Mehmet Gonen <mehmet@status.im>, Daniel Sanchez Quiros <daniel@status.im>, Alvaro Castro-Castilla <alvaro@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Giacomo Pasini <giacomo@logos.co> |
+| Contributors | Thomas Lavaur <thomas@logos.co>, Mehmet Gonen <mehmet@logos.co>, Daniel Sanchez Quiros <daniel@logos.co>, Alvaro Castro-Castilla <alvaro@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/nomosda-network.md
+++ b/docs/blockchain/raw/nomosda-network.md
@@ -6,8 +6,8 @@
 | Slug | 136 |
 | Status | raw |
 | Category | Standards Track |
-| Editor | Daniel Sanchez Quiros <danielsq@status.im> |
-| Contributors | Álvaro Castro-Castilla <alvaro@status.im>, Daniel Kashepava <danielkashepava@status.im>, Gusto Bacvinka <augustinas@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Daniel Sanchez Quiros <danielsq@logos.co> |
+| Contributors | Álvaro Castro-Castilla <alvaro@logos.co>, Daniel Kashepava <danielkashepava@logos.co>, Gusto Bacvinka <augustinas@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/p2p-hardware-requirements.md
+++ b/docs/blockchain/raw/p2p-hardware-requirements.md
@@ -6,8 +6,8 @@
 | Slug | 137 |
 | Status | raw |
 | Category | infrastructure |
-| Editor | Daniel Sanchez-Quiros <danielsq@status.im> |
-| Contributors | Filip Dimitrijevic <filip@status.im> |
+| Editor | Daniel Sanchez-Quiros <danielsq@logos.co> |
+| Contributors | Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/p2p-nat-solution.md
+++ b/docs/blockchain/raw/p2p-nat-solution.md
@@ -6,8 +6,8 @@
 | Slug | 138 |
 | Status | raw |
 | Category | networking |
-| Editor | Antonio Antonino <antonio@status.im> |
-| Contributors | Álvaro Castro-Castilla <alvaro@status.im>, Daniel Sanchez-Quiros <danielsq@status.im>, Petar Radovic <petar@status.im>, Gusto Bacvinka <augustinas@status.im>, Youngjoon Lee <youngjoon@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Antonio Antonino <antonio@logos.co> |
+| Contributors | Álvaro Castro-Castilla <alvaro@logos.co>, Daniel Sanchez-Quiros <danielsq@logos.co>, Petar Radovic <petar@logos.co>, Gusto Bacvinka <augustinas@logos.co>, Youngjoon Lee <youngjoon@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 

--- a/docs/blockchain/raw/p2p-network-bootstrapping.md
+++ b/docs/blockchain/raw/p2p-network-bootstrapping.md
@@ -6,8 +6,8 @@
 | Slug | 134 |
 | Status | raw |
 | Category | networking |
-| Editor | Daniel Sanchez-Quiros <danielsq@status.im> |
-| Contributors | Álvaro Castro-Castilla <alvaro@status.im>, Petar Radovic <petar@status.im>, Gusto Bacvinka <augustinas@status.im>, Antonio Antonino <antonio@status.im>, Youngjoon Lee <youngjoon@status.im>, Filip Dimitrijevic <filip@status.im> |
+| Editor | Daniel Sanchez-Quiros <danielsq@logos.co> |
+| Contributors | Álvaro Castro-Castilla <alvaro@logos.co>, Petar Radovic <petar@logos.co>, Gusto Bacvinka <augustinas@logos.co>, Antonio Antonino <antonio@logos.co>, Youngjoon Lee <youngjoon@logos.co>, Filip Dimitrijevic <filip@logos.co> |
 
 <!-- timeline:start -->
 


### PR DESCRIPTION
## Summary

Migrates Editor and Contributors emails across all blockchain specs from `@status.im` to `@logos.co`. Local parts unchanged; only the domain flips.

- 28 files modified
- 21 unique emails affected
- 52 line replacements (symmetric +/-)
- Scope: `docs/blockchain/` only — other sections (messaging, storage, ift-ts) untouched per request

## Test plan

- [ ] CI passes (lint + remark)
- [ ] No remaining `@status.im` references in `docs/blockchain/`
- [ ] All 28 modified files still render correctly via `mdbook build`