### PR TITLE
chore(blockchain): mirror Notion topology in SUMMARY sidebar

### DIFF
--- a/scripts/blockchain_structure.py
+++ b/scripts/blockchain_structure.py
@@ -1,0 +1,147 @@
+"""
+Topic groupings for the Blockchain section in lip.logos.co.
+
+Mirrors the layout at
+https://nomos-tech.notion.site/Specifications-345261aa09df80bf968cd21b1e3e9563
+
+`gen_summary.py` reads this config when building SUMMARY.md entries for
+blockchain. Each existing spec file is placed under its mapped topic, and
+the bucket is derived from the file's `Status` metadata field at
+generation time. Notion-only entries that have not yet been migrated to
+GitHub are emitted as draft (greyed) links so the full target structure
+stays visible to readers and reviewers.
+"""
+
+# Order in which topics appear on the site (under "Logos Blockchain — The Bedrock").
+TOPIC_ORDER = [
+    "P2P Network",
+    "Consensus",
+    "Mantle",
+    "Cryptoeconomics",
+    "Blend Network",
+    "Cryptography",
+    "Data Availability",
+]
+
+# Default per-topic bucket order. Override below if a topic uses a different set.
+DEFAULT_BUCKETS = ["Merged", "Stable", "Deprecated", "Retired", "Deleted"]
+
+# Per-topic bucket overrides where Notion uses a different set.
+TOPIC_BUCKETS = {
+    "P2P Network": ["Merged", "Stable", "Deprecated", "Retired"],
+}
+
+# COSS `Status` field -> Notion bucket name.
+STATUS_TO_BUCKET = {
+    "raw": "Merged",
+    "draft": "Merged",
+    "approved": "Merged",
+    "stable": "Stable",
+    "verified": "Stable",
+    "deprecated": "Deprecated",
+    "retired": "Retired",
+    "deleted": "Deleted",
+}
+
+# File path (relative to `docs/`) -> (topic, Notion display label).
+# Bucket is taken from the file's `Status` metadata at generation time.
+FILE_ASSIGNMENTS = {
+    # P2P Network
+    "blockchain/draft/p2p-network.md": ("P2P Network", "P2P Network"),
+    "blockchain/raw/p2p-nat-solution.md": ("P2P Network", "P2P Nat Solution"),
+    "blockchain/raw/p2p-network-bootstrapping.md": ("P2P Network", "P2P Network Bootstrapping"),
+    "blockchain/raw/p2p-hardware-requirements.md": ("P2P Network", "Hardware Requirements"),
+
+    # Consensus
+    "blockchain/raw/nomos-cryptarchia-v1-protocol.md": ("Consensus", "Cryptarchia Protocol"),
+    "blockchain/raw/cryptarchia-v1-bootstr-sync.md": ("Consensus", "Cryptarchia Bootstrapping & Synchronization"),
+    "blockchain/raw/fork-choice.md": ("Consensus", "Cryptarchia Fork Choice Rule"),
+    "blockchain/raw/cryptarchia-total-stake-inference.md": ("Consensus", "Total Stake Inference"),
+    "blockchain/raw/cryptarchia-proof-of-leadership.md": ("Consensus", "Proof of Leadership"),
+    "blockchain/deprecated/claro.md": ("Consensus", "Claro Consensus Protocol"),
+
+    # Mantle
+    "blockchain/raw/bedrock-architecture-overview.md": ("Mantle", "[Overview] Bedrock Architecture"),
+    "blockchain/raw/bedrock-v1.1-mantle-specification.md": ("Mantle", "Mantle"),
+    "blockchain/raw/bedrock-v1.1-block-construction.md": ("Mantle", "Block Construction, Validation and Execution"),
+    "blockchain/raw/bedrock-genesis-block.md": ("Mantle", "Bedrock Genesis Block"),
+    "blockchain/raw/bedrock-service-declaration-protocol.md": ("Mantle", "Service Declaration Protocol"),
+    "blockchain/raw/bedrock-service-reward-distribution.md": ("Mantle", "Service Reward Distribution Protocol"),
+    "blockchain/raw/nomos-wallet-technical-standard.md": ("Mantle", "Wallet Technical Standard"),
+    "blockchain/raw/bedrock-anonymous-leaders-reward.md": ("Mantle", "Anonymous Leaders Reward Protocol"),
+
+    # Blend Network
+    "blockchain/raw/nomos-blend-protocol.md": ("Blend Network", "Blend Protocol"),
+    "blockchain/raw/nomos-key-types-and-generation.md": ("Blend Network", "Key Types and Generation"),
+    "blockchain/raw/nomos-proof-of-quota.md": ("Blend Network", "Proof of Quota"),
+    "blockchain/raw/nomos-message-encapsulation.md": ("Blend Network", "Message Encapsulation Mechanism"),
+    "blockchain/raw/nomos-message-formatting.md": ("Blend Network", "Message Formatting"),
+    "blockchain/raw/nomos-payload-formatting.md": ("Blend Network", "Payload Formatting"),
+
+    # Cryptography
+    "blockchain/raw/digital-signature.md": ("Cryptography", "Digital Signature"),
+
+    # Data Availability (not in current Notion outline; confirm placement with team).
+    "blockchain/raw/nomosda-network.md": ("Data Availability", "DA Network"),
+    "blockchain/raw/da-cryptographic-protocol.md": ("Data Availability", "DA Cryptographic Protocol"),
+    "blockchain/raw/da-rewarding.md": ("Data Availability", "DA Rewarding"),
+}
+
+# Entries that exist in Notion but have not yet been migrated to GitHub.
+# Render as draft (greyed) links so the full target structure stays visible.
+PLACEHOLDERS = {
+    "P2P Network": {
+        "Merged": ["Network Wire Format"],
+    },
+    "Consensus": {
+        "Merged": [
+            "[Analysis] Cryptarchia De-anonymisation of Relative Stake",
+            "[Analysis] Total Stake Inference",
+            "[Analysis] Block Times & Blend Network",
+        ],
+    },
+    "Mantle": {
+        "Merged": [
+            "Mantle Transaction Encoding",
+            "[Template] Cross-Channel Messaging",
+            "[Analysis] Gas Cost Determination",
+        ],
+    },
+    "Cryptoeconomics": {
+        "Merged": [
+            "[Overview] Cryptoeconomics",
+            "Block Rewards",
+            "Execution Market",
+            "Storage Markets",
+            "[Analysis] Block Rewards",
+            "[Analysis] Static Minimum Stake Estimation for Service Declaration Protocol",
+            "[Analysis] Block Reward Parameter Calibration",
+            "[Analysis] Storage Market",
+            "[Analysis] Execution Market",
+        ],
+    },
+    "Blend Network": {
+        "Merged": [
+            "[Analysis] Impact of the Service Declaration Protocol on the Statistical Inference",
+            "[Analysis] Queuing System in the Mix Node",
+            "[Analysis] Anonymity",
+            "[Analysis] Correlation Functions",
+            "[Analysis] Communication on Trees",
+            "[Analysis] Resilience and Anonymity",
+            "[Analysis] Latency",
+        ],
+    },
+    "Cryptography": {
+        "Merged": [
+            "Common Cryptographic Components",
+            "Trusted Setup Ceremony",
+        ],
+    },
+}
+
+# Label for the group containing all topics.
+BEDROCK_LABEL = "Logos Blockchain — The Bedrock"
+
+
+def buckets_for_topic(topic: str) -> list:
+    return TOPIC_BUCKETS.get(topic, DEFAULT_BUCKETS)

--- a/scripts/gen_summary.py
+++ b/scripts/gen_summary.py
@@ -6,10 +6,12 @@ This keeps a consistent navigation structure for mdBook without manual edits.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import re
 from typing import Iterable, List, Optional
+
+import blockchain_structure as bc
 
 ROOT = Path(__file__).resolve().parent.parent
 DOCS = ROOT / "docs"
@@ -80,8 +82,8 @@ ACRONYMS = {
 @dataclass
 class Item:
     label: str
-    path: Path
-    children: List["Item"]
+    path: Optional[Path]  # None -> rendered as a draft (greyed) entry: `[Label]()`
+    children: List["Item"] = field(default_factory=list)
 
 
 def read_h1(path: Path) -> Optional[str]:
@@ -201,13 +203,67 @@ def build_items(base: Path, rel_base: Path) -> List[Item]:
     return sections + items
 
 
+def escape_label(label: str) -> str:
+    """Escape `[` and `]` so they survive Markdown link-text parsing."""
+    return label.replace("[", "\\[").replace("]", "\\]")
+
+
 def render_items(items: Iterable[Item], depth: int, lines: List[str]) -> None:
     indent = "  " * depth
     for item in items:
-        rel = item.path.relative_to(DOCS).as_posix()
-        lines.append(f"{indent}- [{item.label}]({rel})")
+        label = escape_label(item.label)
+        if item.path is None:
+            lines.append(f"{indent}- [{label}]()")
+        else:
+            rel = item.path.relative_to(DOCS).as_posix()
+            lines.append(f"{indent}- [{label}]({rel})")
         if item.children:
             render_items(item.children, depth + 1, lines)
+
+
+def read_status(path: Path) -> Optional[str]:
+    """Return the lowercased value of the `Status` row in a spec metadata table."""
+    try:
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = re.match(r"^\|\s*Status\s*\|\s*([^|]+?)\s*\|", line, re.IGNORECASE)
+            if m:
+                return m.group(1).strip().lower()
+    except OSError:
+        pass
+    return None
+
+
+def build_blockchain_items() -> List[Item]:
+    """
+    Build the Blockchain section under the Notion-style topology defined in
+    `blockchain_structure.py`. Each spec lands under its mapped topic; the
+    bucket is derived from its `Status` field. Notion-only entries are emitted
+    as draft links so the full target structure stays visible.
+    """
+    # Group real files by (topic, bucket).
+    grouped: dict = {topic: {b: [] for b in bc.buckets_for_topic(topic)} for topic in bc.TOPIC_ORDER}
+    for rel_path, (topic, label) in bc.FILE_ASSIGNMENTS.items():
+        abs_path = DOCS / rel_path
+        if not abs_path.exists():
+            continue
+        status = read_status(abs_path) or "raw"
+        bucket = bc.STATUS_TO_BUCKET.get(status, "Merged")
+        if bucket not in grouped[topic]:
+            grouped[topic][bucket] = []
+        grouped[topic][bucket].append(Item(label=label, path=abs_path))
+
+    topic_items: List[Item] = []
+    for topic in bc.TOPIC_ORDER:
+        bucket_items: List[Item] = []
+        placeholders = bc.PLACEHOLDERS.get(topic, {})
+        for bucket in bc.buckets_for_topic(topic):
+            children: List[Item] = sorted(grouped[topic].get(bucket, []), key=lambda i: i.label.lower())
+            for placeholder_label in placeholders.get(bucket, []):
+                children.append(Item(label=placeholder_label, path=None))
+            bucket_items.append(Item(label=bucket, path=None, children=children))
+        topic_items.append(Item(label=topic, path=None, children=bucket_items))
+
+    return [Item(label=bc.BEDROCK_LABEL, path=None, children=topic_items)]
 
 
 def main() -> None:
@@ -226,7 +282,10 @@ def main() -> None:
             continue
         label = LABEL_OVERRIDES.get(section, humanize(section))
         lines.append(f"- [{label}]({section}/{readme.name})")
-        children = build_items(section_dir, Path(section))
+        if section == "blockchain":
+            children = build_blockchain_items()
+        else:
+            children = build_items(section_dir, Path(section))
         render_items(children, 1, lines)
         lines.append("")
 

--- a/scripts/validate_generated_outputs.py
+++ b/scripts/validate_generated_outputs.py
@@ -16,7 +16,7 @@ from validate_metadata import DOCS, ROOT, discover_docs, read_doc
 SUMMARY = DOCS / "SUMMARY.md"
 INDEX = DOCS / "logos-lips.json"
 EXCLUDE_INDEX_PARTS = {"previous-versions"}
-SUMMARY_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+\.md(?:#[^)]+)?)\)")
+SUMMARY_LINK_RE = re.compile(r"\[(?:\\.|[^\]\\])+\]\(([^)]+\.md(?:#[^)]+)?)\)")
 
 
 def parse_summary_links() -> Tuple[set[Path], List[str]]:


### PR DESCRIPTION
## Summary

Reorganises the Blockchain section on lip.logos.co from a flat list of every spec under Raw / Deprecated to the topic-and-status hierarchy used at the [Notion Specifications page](https://nomos-tech.notion.site/Specifications-345261aa09df80bf968cd21b1e3e9563), confirmed by the Logos Blockchain team.

The new sidebar layout is:

```
Blockchain
  Logos Blockchain — The Bedrock
    P2P Network        → Merged | Stable | Deprecated | Retired
    Consensus          → Merged | Stable | Deprecated | Retired | Deleted
    Mantle             → Merged | Stable | Deprecated | Retired | Deleted
    Cryptoeconomics    → Merged | Stable | Deprecated | Retired | Deleted
    Blend Network      → Merged | Stable | Deprecated | Retired | Deleted
    Cryptography       → Merged | Stable | Deprecated | Retired | Deleted
    Data Availability  → Merged | Stable | Deprecated | Retired | Deleted
```

`Data Availability` is added as a 7th topic — three DA specs (`DA Network`, `DA Cryptographic Protocol`, `DA Rewarding`) exist in the repo but are not in the current Notion outline. Worth confirming the placement with the team; trivial to move later.

## How it works

- `scripts/blockchain_structure.py` declares topic order, file → topic mapping, and the COSS Status → Notion bucket mapping. Notion-only entries that have not yet been migrated to GitHub are listed as placeholders.
- `scripts/gen_summary.py` reads that config when building the blockchain section. Buckets are derived from each spec's `Status` metadata field at generation time, so a status promotion (`raw → draft → stable`) automatically rebuckets the spec with no config edit.
- Topic / bucket headers and not-yet-migrated specs are emitted as draft Markdown links (`[Label]()`), which mdbook renders as greyed, non-clickable entries. This keeps the full target structure visible while making the gap (Cryptoeconomics is entirely TBD; Cryptography has only Digital Signature) obvious to readers.
- `scripts/validate_generated_outputs.py` SUMMARY link regex was updated to accept escaped brackets in link text (needed for labels like `[Overview] Bedrock Architecture`).

No spec files were moved. Other top-level sections (`messaging`, `storage`, `anoncomms`, `research`) keep their existing directory-driven layout.

## Out of scope (follow-up PR)

- Status / content reclassification of existing specs (`raw → draft → stable → deprecated → retired → deleted`)
- Migration of the Notion-only placeholders into real spec files
- Cross-checking spec content against Notion versions (the diff Filip flagged)

## Test plan

- [ ] CI passes (`validate_metadata`, `gen_summary`, `validate_generated_outputs`, markdownlint, mdbook build)
- [ ] Sidebar renders the new hierarchy with no broken links (verified locally via `mdbook serve`)
- [ ] Greyed placeholder entries appear non-clickable as expected
- [ ] All 28 existing specs land in their mapped topic / bucket