### PR TITLE
chore(blockchain): mirror SUMMARY tree on the Blockchain landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ book
 node_modules
 docs/logos-lips.json
 docs/SUMMARY.md
+docs/blockchain-structure.json
 .DS_Store
 __pycache__

--- a/custom.css
+++ b/custom.css
@@ -429,3 +429,149 @@ code, pre, .hljs {
 .chapter-item:not(.expanded) > a .section-toggle::before {
     transform: rotate(0deg);
 }
+
+/* ---------- Blockchain topic tree (mirrors SUMMARY sidebar) ---------- */
+
+.blockchain-tree-section {
+    margin: 1.25rem 0 1.75rem;
+}
+
+.blockchain-tree-heading {
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    opacity: 0.85;
+}
+
+.blockchain-tree {
+    border: 1px solid var(--table-border-color, rgba(127, 127, 127, 0.2));
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    background: var(--sidebar-bg, transparent);
+}
+
+.blockchain-tree-loading,
+.blockchain-tree-error {
+    margin: 0;
+    color: var(--fg-muted, #888);
+    font-style: italic;
+}
+
+.blockchain-tree details {
+    margin: 0;
+}
+
+.blockchain-tree summary {
+    cursor: pointer;
+    list-style: none;
+    padding: 2px 0;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.blockchain-tree summary::-webkit-details-marker {
+    display: none;
+}
+
+.blockchain-tree summary::before {
+    content: "▸";
+    display: inline-block;
+    font-size: 0.75em;
+    width: 0.8em;
+    transition: transform 0.15s ease;
+    opacity: 0.6;
+}
+
+.blockchain-tree details[open] > summary::before {
+    transform: rotate(90deg);
+}
+
+.blockchain-tree .tree-root > summary {
+    font-weight: 600;
+    font-size: 1.05rem;
+    margin-bottom: 0.4rem;
+}
+
+.blockchain-tree .tree-topics {
+    padding-left: 1.1rem;
+    border-left: 1px solid rgba(127, 127, 127, 0.18);
+    margin-left: 0.35rem;
+}
+
+.blockchain-tree .tree-topic > summary {
+    font-weight: 600;
+    margin-top: 0.35rem;
+}
+
+.blockchain-tree .tree-buckets {
+    padding-left: 1.1rem;
+}
+
+.blockchain-tree .tree-bucket {
+    margin: 0.15rem 0;
+}
+
+.blockchain-tree .tree-bucket > summary {
+    font-size: 0.95rem;
+}
+
+.blockchain-tree .tree-bucket-empty > summary {
+    opacity: 0.5;
+    font-style: italic;
+}
+
+.blockchain-tree .tree-bucket-count {
+    font-size: 0.8rem;
+    opacity: 0.6;
+    margin-left: 0.25rem;
+}
+
+.blockchain-tree .tree-specs {
+    list-style: none;
+    padding-left: 1.4rem;
+    margin: 0.15rem 0 0.3rem;
+}
+
+.blockchain-tree .tree-spec {
+    padding: 2px 0;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.blockchain-tree .tree-spec a {
+    text-decoration: none;
+}
+
+.blockchain-tree .tree-spec a:hover {
+    text-decoration: underline;
+}
+
+.blockchain-tree .tree-spec-placeholder .tree-spec-label {
+    color: var(--fg-muted, #888);
+    font-style: italic;
+}
+
+.blockchain-tree .tree-badge {
+    display: inline-block;
+    padding: 0 0.4rem;
+    border-radius: 8px;
+    font-size: 0.7rem;
+    line-height: 1.5;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    background: rgba(127, 127, 127, 0.18);
+    color: inherit;
+}
+
+.blockchain-tree .tree-badge-raw       { background: rgba(255, 165, 0, 0.18);  color: #d87a00; }
+.blockchain-tree .tree-badge-draft     { background: rgba(0, 140, 220, 0.18);  color: #2486c5; }
+.blockchain-tree .tree-badge-approved  { background: rgba(120, 60, 220, 0.18); color: #7d4ad9; }
+.blockchain-tree .tree-badge-stable    { background: rgba(60, 180, 90, 0.18);  color: #2f9b54; }
+.blockchain-tree .tree-badge-verified  { background: rgba(60, 180, 160, 0.18); color: #2a9a85; }
+.blockchain-tree .tree-badge-deprecated{ background: rgba(200, 80, 80, 0.18);  color: #c4554e; }
+.blockchain-tree .tree-badge-retired   { background: rgba(120, 120, 120, 0.22);color: #888; }
+.blockchain-tree .tree-badge-deleted   { background: rgba(60, 60, 60, 0.35);   color: #aaa; }
+.blockchain-tree .tree-badge-tbd       { background: rgba(120, 120, 120, 0.18);color: #888; font-style: normal; }

--- a/docs/blockchain/README.md
+++ b/docs/blockchain/README.md
@@ -5,6 +5,13 @@ scalable infrastructure for developers creating applications for the network sta
 Published Specifications are currently available here,
 [Blockchain Specifications](https://nomos-tech.notion.site/project).
 
+<section class="blockchain-tree-section">
+  <h2 class="blockchain-tree-heading">Browse by topic</h2>
+  <div id="blockchain-tree-container" class="blockchain-tree" data-source="../blockchain-structure.json">
+    <p class="blockchain-tree-loading">Loading topic tree…</p>
+  </div>
+</section>
+
 <div class="landing-hero">
   <div class="filter-row">
     <input id="rfc-search" type="search" placeholder="Search by number, title, status" aria-label="Search LIPs">

--- a/scripts/gen_summary.py
+++ b/scripts/gen_summary.py
@@ -7,6 +7,7 @@ This keeps a consistent navigation structure for mdBook without manual edits.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
 import re
 from typing import Iterable, List, Optional
@@ -16,6 +17,7 @@ import blockchain_structure as bc
 ROOT = Path(__file__).resolve().parent.parent
 DOCS = ROOT / "docs"
 OUTPUT = DOCS / "SUMMARY.md"
+BLOCKCHAIN_TREE_JSON = DOCS / "blockchain-structure.json"
 
 SKIP_FILES = {"README.md", "SUMMARY.md", "template.md"}
 
@@ -266,6 +268,42 @@ def build_blockchain_items() -> List[Item]:
     return [Item(label=bc.BEDROCK_LABEL, path=None, children=topic_items)]
 
 
+def build_blockchain_tree_data() -> dict:
+    """
+    Same topology as `build_blockchain_items`, but emitted as a JSON-friendly
+    dict for the in-page tree view on the Blockchain landing page.
+    Each spec entry carries its `path` (relative to docs/) and `status`.
+    Placeholder entries have `path: null` and `status: null`.
+    """
+    grouped: dict = {topic: {b: [] for b in bc.buckets_for_topic(topic)} for topic in bc.TOPIC_ORDER}
+    for rel_path, (topic, label) in bc.FILE_ASSIGNMENTS.items():
+        abs_path = DOCS / rel_path
+        if not abs_path.exists():
+            continue
+        status = read_status(abs_path) or "raw"
+        bucket = bc.STATUS_TO_BUCKET.get(status, "Merged")
+        if bucket not in grouped[topic]:
+            grouped[topic][bucket] = []
+        grouped[topic][bucket].append({
+            "label": label,
+            "path": rel_path,
+            "status": status,
+        })
+
+    topics_out = []
+    for topic in bc.TOPIC_ORDER:
+        placeholders = bc.PLACEHOLDERS.get(topic, {})
+        buckets_out = []
+        for bucket in bc.buckets_for_topic(topic):
+            specs = sorted(grouped[topic].get(bucket, []), key=lambda s: s["label"].lower())
+            for placeholder_label in placeholders.get(bucket, []):
+                specs.append({"label": placeholder_label, "path": None, "status": None})
+            buckets_out.append({"name": bucket, "specs": specs})
+        topics_out.append({"name": topic, "buckets": buckets_out})
+
+    return {"label": bc.BEDROCK_LABEL, "topics": topics_out}
+
+
 def main() -> None:
     lines: List[str] = ["# Summary", ""]
 
@@ -291,6 +329,12 @@ def main() -> None:
 
     OUTPUT.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
     print(f"Wrote {OUTPUT}")
+
+    tree_data = build_blockchain_tree_data()
+    BLOCKCHAIN_TREE_JSON.write_text(
+        json.dumps(tree_data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote {BLOCKCHAIN_TREE_JSON}")
 
 
 if __name__ == "__main__":

--- a/scripts/logos-lips.js
+++ b/scripts/logos-lips.js
@@ -704,4 +704,134 @@
       console.error(err);
       resultsCount.textContent = "Failed to load RFC index.";
     });
+
+  /* ---------- Blockchain topic tree (mirrors the SUMMARY sidebar) ---------- */
+
+  const treeContainer = document.getElementById("blockchain-tree-container");
+  if (treeContainer) {
+    const TREE_STATUS_LABELS = {
+      raw: "Raw",
+      draft: "Draft",
+      approved: "Approved",
+      stable: "Stable",
+      verified: "Verified",
+      deprecated: "Deprecated",
+      retired: "Retired",
+      deleted: "Deleted",
+    };
+
+    const treeSource = `${rootPrefix}blockchain-structure.json`;
+
+    function buildTreeSpec(spec) {
+      const li = document.createElement("li");
+      li.className = spec.path ? "tree-spec" : "tree-spec tree-spec-placeholder";
+
+      if (spec.path) {
+        const a = document.createElement("a");
+        a.href = `${rootPrefix}${spec.path.replace(/\.md(#.*)?$/, ".html$1")}`;
+        a.textContent = spec.label;
+        li.appendChild(a);
+      } else {
+        const span = document.createElement("span");
+        span.className = "tree-spec-label";
+        span.textContent = spec.label;
+        li.appendChild(span);
+        const tbd = document.createElement("span");
+        tbd.className = "tree-badge tree-badge-tbd";
+        tbd.textContent = "TBD";
+        li.appendChild(tbd);
+      }
+
+      if (spec.status && TREE_STATUS_LABELS[spec.status]) {
+        const badge = document.createElement("span");
+        badge.className = `tree-badge tree-badge-${spec.status}`;
+        badge.textContent = TREE_STATUS_LABELS[spec.status];
+        li.appendChild(badge);
+      }
+
+      return li;
+    }
+
+    function buildTreeBucket(bucket) {
+      const realCount = bucket.specs.filter((s) => s.path).length;
+      const totalCount = bucket.specs.length;
+
+      const details = document.createElement("details");
+      details.className = totalCount === 0 ? "tree-bucket tree-bucket-empty" : "tree-bucket";
+
+      const summary = document.createElement("summary");
+      summary.className = "tree-bucket-summary";
+      summary.appendChild(document.createTextNode(bucket.name));
+
+      const count = document.createElement("span");
+      count.className = "tree-bucket-count";
+      if (totalCount === 0) {
+        count.textContent = "empty";
+      } else if (realCount === totalCount) {
+        count.textContent = String(totalCount);
+      } else {
+        count.textContent = `${realCount} of ${totalCount}`;
+      }
+      summary.appendChild(count);
+      details.appendChild(summary);
+
+      if (totalCount > 0) {
+        const ul = document.createElement("ul");
+        ul.className = "tree-specs";
+        bucket.specs.forEach((spec) => ul.appendChild(buildTreeSpec(spec)));
+        details.appendChild(ul);
+      }
+
+      return details;
+    }
+
+    function buildTreeTopic(topic) {
+      const details = document.createElement("details");
+      details.className = "tree-topic";
+
+      const summary = document.createElement("summary");
+      summary.className = "tree-topic-summary";
+      summary.textContent = topic.name;
+      details.appendChild(summary);
+
+      const inner = document.createElement("div");
+      inner.className = "tree-buckets";
+      topic.buckets.forEach((bucket) => inner.appendChild(buildTreeBucket(bucket)));
+      details.appendChild(inner);
+
+      return details;
+    }
+
+    function buildTreeRoot(data) {
+      const root = document.createElement("details");
+      root.className = "tree-root";
+      root.open = true;
+
+      const summary = document.createElement("summary");
+      summary.className = "tree-root-summary";
+      summary.textContent = data.label;
+      root.appendChild(summary);
+
+      const inner = document.createElement("div");
+      inner.className = "tree-topics";
+      data.topics.forEach((topic) => inner.appendChild(buildTreeTopic(topic)));
+      root.appendChild(inner);
+
+      return root;
+    }
+
+    fetch(treeSource)
+      .then((resp) => {
+        if (!resp.ok) throw new Error(resp.statusText);
+        return resp.json();
+      })
+      .then((data) => {
+        treeContainer.innerHTML = "";
+        treeContainer.appendChild(buildTreeRoot(data));
+      })
+      .catch((err) => {
+        console.error("Blockchain tree:", err);
+        treeContainer.innerHTML = '<p class="blockchain-tree-error">Failed to load topic tree.</p>';
+      });
+  }
 })();


### PR DESCRIPTION
## Summary

Adds a "Browse by topic" tree to the Blockchain landing page (`docs/blockchain/README.md`) that mirrors the Notion-style hierarchy already shown in the SUMMARY sidebar (introduced in #339). The existing filterable / searchable RFC table is preserved directly below it, so both navigation modes coexist on the same page.

## How it works

- `scripts/gen_summary.py` now also emits `docs/blockchain-structure.json` (in addition to `SUMMARY.md`). Same source of truth: topic order, file → topic mapping (from `blockchain_structure.py`), and per-spec status read from the metadata table at generation time. Notion-only entries land with `path: null`.
- `scripts/logos-lips.js` gains a tree renderer that fetches the JSON and builds nested `<details>` elements. Specs render with a status badge (Raw / Draft / Stable / Deprecated / ...); not-yet-migrated placeholders render greyed with a TBD badge.
- `docs/blockchain/README.md` gets a `#blockchain-tree-container` div above the existing landing-hero.
- `custom.css` adds tree styling (borders, indents, badge colours).
- `.gitignore` picks up the new generated JSON file.

No other top-level sections (messaging, storage, anoncomms, research) are affected. No spec files were moved or modified.

## Out of scope (PR #2, later)

- Status reclassification (raw → draft → stable → deprecated etc.) for existing specs
- Migration of Notion-only placeholder entries into real spec files
- Content diff between Notion and LIPs versions

## Test plan

- [ ] CI passes (`validate_metadata`, `gen_summary`, `validate_generated_outputs`, mdbook build)
- [ ] `/blockchain/index.html` shows the tree above the table; tree expands/collapses per bucket
- [ ] Real specs link to their pages, placeholders are non-clickable and styled greyed
- [ ] Status badges match each spec's current `Status` field